### PR TITLE
feat: add retry logic with exponential backoff to fetcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,11 @@ Content-based arXiv paper recommender system using DistilBERT embeddings.
 
 ## Commands
 ```bash
-pip install -e ".[dev]"      # Install dependencies
-python -m pytest            # Run tests
-python -m pytest tests/path/to/test_file.py::TestClass::test_method  # Single test
-python3 -m arxiv_recommender.bin.cli --config path/to/config.json   # Run CLI
+uv run python -m pytest            # Run tests (uv)
+uv run ruff check .                 # Run linting (uv)
+uv run python -m mypy               # Run type checking (uv)
+uv run python -m pytest tests/path/to/test_file.py::TestClass::test_method  # Single test
+python3 -m arxiv_recommender.cli --config path/to/config.json   # Run CLI
 ```
 
 ## Project Structure
@@ -42,6 +43,10 @@ arxiv_recommender/
 - Branch: `feat/<name>`, `fix/<name>`, `chore/<name>`
 - Commit: `<type>: <description>` (e.g., `feat: add user auth`)
 - PR title: `feat: add user auth`
+- **Before every push**: Run local CI (lint + typecheck + tests):
+  ```bash
+  uv run ruff check . && uv run python -m mypy && uv run python -m pytest
+  ```
 
 ## Prohibitions
 - **Never** commit secrets: `.env`, `credentials.json`

--- a/src/arxiv_recommender/arxiv_paper_fetcher/fetcher.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/fetcher.py
@@ -3,6 +3,7 @@ import requests
 from typing import Optional
 
 from arxiv_recommender.schemas import Paper
+from arxiv_recommender.utils.retry import retry_with_backoff
 from .parser import parse_paper_info, parse_papers
 from .utils import format_arxiv_query
 
@@ -27,6 +28,7 @@ class ArxivFetcher:
         self.max_results = max_results
         self.timeout = timeout
 
+    @retry_with_backoff(max_retries=3, initial_delay=1.0, backoff_factor=2.0)
     def get_paper_by_id(self, paper_id: str) -> Optional[Paper]:
         """
         Fetches a single paper's title and abstract using its arXiv ID.
@@ -41,15 +43,12 @@ class ArxivFetcher:
             requests.RequestException: If the API request fails.
         """
         url = f"{self.base_url}id_list={paper_id}"
-        try:
-            response = requests.get(url, timeout=10)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logging.error(f"Failed to fetch paper {paper_id}: {e}")
-            raise
+        response = requests.get(url, timeout=self.timeout)
+        response.raise_for_status()
 
         return parse_paper_info(response.text)
 
+    @retry_with_backoff(max_retries=3, initial_delay=1.0, backoff_factor=2.0)
     def get_daily_papers(
         self, date: Optional[str] = None, category: Optional[str] = None
     ) -> list[Paper]:
@@ -72,12 +71,8 @@ class ArxivFetcher:
         logging.info(f"Fetching daily papers with query: {query}")
         url = f"{self.base_url}{query}&max_results={self.max_results}"
 
-        try:
-            response = requests.get(url, timeout=10)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logging.error(f"Failed to fetch daily papers: {e}")
-            raise
+        response = requests.get(url, timeout=self.timeout)
+        response.raise_for_status()
 
         papers = parse_papers(response.text)
         logging.info(

--- a/src/arxiv_recommender/utils/retry.py
+++ b/src/arxiv_recommender/utils/retry.py
@@ -1,0 +1,57 @@
+import logging
+import time
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+import requests
+
+T = TypeVar("T")
+
+
+def retry_with_backoff(
+    max_retries: int = 3,
+    initial_delay: float = 1.0,
+    backoff_factor: float = 2.0,
+    exceptions: tuple = (requests.RequestException,),
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """
+    Decorator that retries a function with exponential backoff.
+
+    Args:
+        max_retries (int): Maximum number of retry attempts (default: 3).
+        initial_delay (float): Initial delay in seconds (default: 1.0).
+        backoff_factor (float): Multiplier for delay after each retry (default: 2.0).
+        exceptions (tuple): Tuple of exception types to catch and retry (default: requests.RequestException).
+
+    Returns:
+        Callable: Decorated function that retries on failure.
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            delay = initial_delay
+            last_exception: Exception | None = None
+
+            for attempt in range(max_retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    last_exception = e
+                    if attempt < max_retries:
+                        logging.warning(
+                            f"Attempt {attempt + 1}/{max_retries + 1} failed: {e}. "
+                            f"Retrying in {delay:.1f}s..."
+                        )
+                        time.sleep(delay)
+                        delay *= backoff_factor
+                    else:
+                        logging.error(f"All {max_retries + 1} attempts failed. Last error: {e}")
+
+            if last_exception:
+                raise last_exception
+            raise RuntimeError("Unexpected error in retry_with_backoff")
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary

- Add `utils/retry.py` with `@retry_with_backoff` decorator implementing exponential backoff (1s → 2s → 4s)
- Apply retry decorator to `get_paper_by_id` and `get_daily_papers` methods
- Replace hardcoded timeout=10 with configurable `self.timeout`

This handles transient network failures gracefully when fetching from arXiv API.