### PR TITLE
feat: add embedder abstraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ arxiv_recommender/
 - **Type hints (Python 3.10+)**: Use `X | None` instead of `Optional[X]`
 - Classes: PascalCase, Functions: snake_case
 - Google-style docstrings for public methods
+- Before making any file edits, present the proposed diff and wait for explicit user approval.
 
 ## Three-Tier Boundaries
 | Always | Ask First | Never |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Content-based arXiv paper recommender system using DistilBERT embeddings.
 uv run python -m pytest            # Run tests (uv)
 uv run ruff check .                 # Run linting (uv)
 uv run ruff format --check .        # Run formatting check (uv)
-uv run python -m mypy               # Run type checking (uv)
+uv run python -m mypy src           # Run type checking (uv)
 uv run python -m pytest tests/path/to/test_file.py::TestClass::test_method  # Single test
 python3 -m arxiv_recommender.cli --config path/to/config.json   # Run CLI
 pre-commit run                      # Run all local checks (lint + format + mypy)
@@ -47,7 +47,7 @@ arxiv_recommender/
 - PR title: `feat: add user auth`
 - **Before every push**: Run local CI (lint + format + typecheck + tests):
   ```bash
-  uv run ruff check . && uv run ruff format --check . && uv run python -m mypy && uv run python -m pytest
+  uv run ruff check . && uv run ruff format --check . && uv run python -m mypy src && uv run python -m pytest
   ```
 
 ## Prohibitions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ arxiv_recommender/
 - **Type hints (Python 3.10+)**: Use `X | None` instead of `Optional[X]`
 - Classes: PascalCase, Functions: snake_case
 - Google-style docstrings for public methods
+
+## Collaboration Workflow
 - Before making any file edits, present the proposed diff and wait for explicit user approval.
 
 ## Three-Tier Boundaries

--- a/src/arxiv_recommender/recommendation/recommendation.py
+++ b/src/arxiv_recommender/recommendation/recommendation.py
@@ -5,8 +5,8 @@ from typing import Any
 from sklearn.metrics.pairwise import cosine_similarity
 
 from arxiv_recommender.schemas import Paper
+from arxiv_recommender.text_vectorization import TextEmbedder
 from arxiv_recommender.utils.metrics import MetricsCollector
-from ..text_vectorization import DistilBERTEmbedding
 
 
 class Recommender:
@@ -20,7 +20,7 @@ class Recommender:
 
     def __init__(
         self,
-        vectorizer: DistilBERTEmbedding,
+        vectorizer: TextEmbedder,
         favorite_papers: list[Paper],
         metrics: MetricsCollector | None = None,
     ) -> None:

--- a/src/arxiv_recommender/text_vectorization/__init__.py
+++ b/src/arxiv_recommender/text_vectorization/__init__.py
@@ -1,4 +1,6 @@
+from arxiv_recommender.text_vectorization.base import TextEmbedder
 from arxiv_recommender.text_vectorization.cache import EmbeddingCache
 from arxiv_recommender.text_vectorization.distil_bert import DistilBERTEmbedding
+from arxiv_recommender.text_vectorization.huggingface_embed import HuggingFaceEmbedding
 
-__all__ = ["EmbeddingCache", "DistilBERTEmbedding"]
+__all__ = ["EmbeddingCache", "TextEmbedder", "DistilBERTEmbedding", "HuggingFaceEmbedding"]

--- a/src/arxiv_recommender/text_vectorization/base.py
+++ b/src/arxiv_recommender/text_vectorization/base.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+import numpy as np
+
+
+class TextEmbedder(ABC):
+    """Abstract base class for text embedding models.
+
+    All text vectorization implementations should inherit from this class
+    and implement the ``process`` and ``get_cache_stats`` methods.
+    """
+
+    @abstractmethod
+    def process(self, text: str) -> np.ndarray:
+        """Generate an embedding vector for the given text.
+
+        Args:
+            text: Input text string.
+
+        Returns:
+            A numpy array representing the text embedding.
+        """
+
+    @abstractmethod
+    def get_cache_stats(self) -> dict[str, Any]:
+        """Get cache performance statistics.
+
+        Returns:
+            Dictionary with cache hits, misses, and hit rate.
+        """

--- a/src/arxiv_recommender/text_vectorization/distil_bert.py
+++ b/src/arxiv_recommender/text_vectorization/distil_bert.py
@@ -1,109 +1,22 @@
-import numpy as np
-import torch
-from transformers import DistilBertTokenizer, DistilBertModel
-
-from arxiv_recommender.text_vectorization.cache import EmbeddingCache
+from arxiv_recommender.text_vectorization.huggingface_embed import HuggingFaceEmbedding
 
 
-class DistilBERTEmbedding:
-    """
-    A class using DistilBERT for text vectorization with chunking
-    to handle long sequences.
+class DistilBERTEmbedding(HuggingFaceEmbedding):
+    """Backward-compatible DistilBERT embedder.
 
-    Attributes:
-        model_name (str): Pre-trained DistilBERT model name.
-        tokenizer (DistilBertTokenizer): Tokenizer for DistilBERT.
-        model (DistilBertModel): DistilBERT model for embeddings.
-        max_length (int): Maximum token length per chunk (default: 512).
-        cache (EmbeddingCache): Embedding cache for caching embeddings.
+    Prefer :class:`HuggingFaceEmbedding` for new code. This class preserves
+    existing imports and configs that reference ``DistilBERTEmbedding``.
     """
 
     def __init__(
         self,
         model_name: str = "distilbert-base-uncased",
         cache_size: int = 1000,
-    ):
-        """
-        Initializes the tokenizer and model.
+    ) -> None:
+        """Initializes the DistilBERT-compatible HuggingFace embedder.
 
         Args:
-            model_name (str, optional): Pre-trained DistilBERT model name.
-                                        Defaults to "distilbert-base-uncased".
-            cache_size (int): Maximum number of embeddings to cache.
+            model_name: HuggingFace DistilBERT model path or identifier.
+            cache_size: Maximum number of embeddings to cache.
         """
-        self.model_name = model_name
-        self.tokenizer = DistilBertTokenizer.from_pretrained(model_name)
-        self.model = DistilBertModel.from_pretrained(model_name)
-        self.max_length = 512
-        self.cache = EmbeddingCache(max_size=cache_size)
-
-    def process(self, text: str) -> np.ndarray:
-        """
-        Generates embeddings for a given text by splitting it into chunks
-        and aggregating the chunk embeddings.
-
-        Args:
-            text (str): Input text string.
-
-        Returns:
-            np.ndarray: The aggregated text embedding.
-        """
-        cached_embedding = self.cache.get(text)
-        if cached_embedding is not None:
-            return cached_embedding
-
-        tokenized_chunks = self.tokenize(text)
-        embedding = self.vectorize(tokenized_chunks)
-        result = embedding.cpu().numpy()
-
-        self.cache.put(text, result)
-
-        return result
-
-    def tokenize(self, text: str) -> list[torch.Tensor]:
-        """
-        Tokenizes input text into chunks that fit within DistilBERT's limits.
-
-        Args:
-            text (str): Input text string.
-
-        Returns:
-            list[torch.Tensor]: List of tokenized chunks.
-        """
-        tokens = self.tokenizer(
-            text,
-            return_tensors="pt",
-            truncation=True,
-            padding=True,
-            max_length=self.max_length,
-        )
-        return [tokens["input_ids"], tokens["attention_mask"]]
-
-    def vectorize(self, tokenized_chunks: list[torch.Tensor]) -> torch.Tensor:
-        """Get embedding vectors for tokenized chunks with mean pooling.
-
-        Args:
-            tokenized_chunks: List of tokenized chunks [input_ids, attention_mask].
-
-        Returns:
-            Aggregated text embedding as tensor.
-        """
-        input_ids = tokenized_chunks[0]
-        attention_mask = tokenized_chunks[1]
-
-        with torch.no_grad():
-            outputs = self.model(input_ids, attention_mask=attention_mask)
-            embeddings = outputs.last_hidden_state
-
-        sentence_embedding = torch.mean(embeddings, dim=1)
-        sentence_embedding = torch.mean(sentence_embedding, dim=0, keepdim=False)
-
-        return sentence_embedding
-
-    def get_cache_stats(self) -> dict:
-        """Get cache performance statistics.
-
-        Returns:
-            Dictionary with cache hits, misses, and hit rate.
-        """
-        return self.cache.stats()
+        super().__init__(model_name=model_name, cache_size=cache_size)

--- a/src/arxiv_recommender/text_vectorization/huggingface_embed.py
+++ b/src/arxiv_recommender/text_vectorization/huggingface_embed.py
@@ -1,0 +1,100 @@
+from typing import Any, cast
+
+import numpy as np
+import torch
+from transformers import AutoModel, AutoTokenizer
+
+from arxiv_recommender.text_vectorization.base import TextEmbedder
+from arxiv_recommender.text_vectorization.cache import EmbeddingCache
+
+
+class HuggingFaceEmbedding(TextEmbedder):
+    """Generic HuggingFace text embedder using mean pooled token embeddings."""
+
+    def __init__(
+        self,
+        model_name: str = "distilbert-base-uncased",
+        cache_size: int = 1000,
+    ) -> None:
+        """Initializes tokenizer, model, and embedding cache.
+
+        Args:
+            model_name: HuggingFace model path or identifier.
+            cache_size: Maximum number of embeddings to cache.
+        """
+        self.model_name = model_name
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModel.from_pretrained(model_name)
+        self.model.eval()
+        self.max_length = 512
+        self.cache = EmbeddingCache(max_size=cache_size)
+
+    def process(self, text: str) -> np.ndarray:
+        """Generate an embedding vector for the given text.
+
+        Args:
+            text: Input text string.
+
+        Returns:
+            A numpy array representing the text embedding.
+        """
+        cached_embedding = self.cache.get(text)
+        if cached_embedding is not None:
+            return cached_embedding
+
+        tokenized_text = self.tokenize(text)
+        embedding = self.vectorize(tokenized_text)
+        result = embedding.detach().cpu().numpy()
+        self.cache.put(text, result)
+
+        return result
+
+    def tokenize(self, text: str) -> dict[str, torch.Tensor]:
+        """Tokenizes input text for the configured HuggingFace model.
+
+        Args:
+            text: Input text string.
+
+        Returns:
+            Tokenized tensors keyed by HuggingFace input name.
+        """
+        tokenized_text = self.tokenizer(
+            text,
+            return_tensors="pt",
+            truncation=True,
+            padding=True,
+            max_length=self.max_length,
+        )
+        return cast(dict[str, torch.Tensor], tokenized_text)
+
+    def vectorize(self, tokenized_text: dict[str, torch.Tensor]) -> torch.Tensor:
+        """Get embedding vectors for tokenized text with attention-aware mean pooling.
+
+        Args:
+            tokenized_text: Tokenized HuggingFace model inputs.
+
+        Returns:
+            Mean pooled text embedding as tensor.
+        """
+        with torch.no_grad():
+            outputs = self.model(**tokenized_text)
+
+        embeddings = outputs.last_hidden_state
+        attention_mask = tokenized_text["attention_mask"]
+        return self._mean_pool(embeddings, attention_mask)
+
+    def _mean_pool(self, embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        mask = attention_mask.unsqueeze(-1).expand(embeddings.size()).float()
+        masked_embeddings = embeddings * mask
+        summed_embeddings = torch.sum(masked_embeddings, dim=1)
+        token_counts = torch.clamp(mask.sum(dim=1), min=1e-9)
+        sentence_embeddings = summed_embeddings / token_counts
+        return torch.mean(sentence_embeddings, dim=0, keepdim=False)
+
+    def get_cache_stats(self) -> dict[str, Any]:
+        """Get cache performance statistics.
+
+        Returns:
+            Dictionary with cache hits, misses, and hit rate.
+        """
+        return self.cache.stats()

--- a/src/arxiv_recommender/utils/model_loader.py
+++ b/src/arxiv_recommender/utils/model_loader.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
-from typing import Any
+
+from arxiv_recommender.text_vectorization import TextEmbedder
 
 
 def load_vectorization_model(
@@ -8,7 +9,7 @@ def load_vectorization_model(
     class_name: str,
     model_name: str,
     cache_size: int,
-) -> Any:
+) -> TextEmbedder:
     """
     Dynamically loads a text vectorization model.
 
@@ -19,7 +20,7 @@ def load_vectorization_model(
         cache_size (int): Maximum number of embeddings to cache.
 
     Returns:
-        Type: The loaded model class.
+        Instantiated text embedder.
 
     Raises:
         ImportError: If the model class is not found.
@@ -27,7 +28,15 @@ def load_vectorization_model(
     try:
         module = importlib.import_module(f"arxiv_recommender.text_vectorization.{module_name}")
         model_class = getattr(module, class_name)
-        return model_class(model_name, cache_size=cache_size)
+        model = model_class(model_name, cache_size=cache_size)
+        if not isinstance(model, TextEmbedder):
+            logging.error(
+                "Invalid vectorization model '%s.%s': not a TextEmbedder",
+                module_name,
+                class_name,
+            )
+            raise ImportError(f"Model '{module_name}.{class_name}' is not a TextEmbedder.")
+        return model
     except (ModuleNotFoundError, AttributeError) as e:
-        logging.error(f"Failed to load vectorization model '{module_name}.{class_name}': {e}")
+        logging.error("Failed to load vectorization model '%s.%s': %s", module_name, class_name, e)
         raise ImportError(f"Model '{module_name}.{class_name}' not found.")

--- a/tests/recommendation/test_recommender.py
+++ b/tests/recommendation/test_recommender.py
@@ -1,18 +1,19 @@
 import unittest
-import numpy as np
 from unittest.mock import MagicMock
+
+import numpy as np
 
 from arxiv_recommender.recommendation.recommendation import Recommender
 from arxiv_recommender.schemas import Paper
-from arxiv_recommender.text_vectorization.distil_bert import DistilBERTEmbedding
+from arxiv_recommender.text_vectorization import TextEmbedder
 
 
 class TestRecommender(unittest.TestCase):
     """Unit tests for the Recommender class."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Setup mock vectorizer and sample papers for testing."""
-        self.mock_vectorizer = MagicMock(spec=DistilBERTEmbedding)
+        self.mock_vectorizer = MagicMock(spec=TextEmbedder)
         self.mock_vectorizer.process.side_effect = lambda text: np.array([len(text)])
 
         self.favorite_papers = [
@@ -30,7 +31,7 @@ class TestRecommender(unittest.TestCase):
             vectorizer=self.mock_vectorizer, favorite_papers=self.favorite_papers
         )
 
-    def test_favorite_paper_embeddings_computed_correctly(self):
+    def test_favorite_paper_embeddings_computed_correctly(self) -> None:
         """Test if favorite paper embeddings are computed correctly."""
         expected_embeddings = np.array(
             [[len(p.title + " " + p.abstract)] for p in self.favorite_papers]
@@ -39,7 +40,7 @@ class TestRecommender(unittest.TestCase):
             self.recommender.favorite_paper_embeddings, expected_embeddings
         )
 
-    def test_recommend_by_papers_with_valid_candidates(self):
+    def test_recommend_by_papers_with_valid_candidates(self) -> None:
         """Test if recommendations are correctly ranked by similarity."""
         recommendations = self.recommender.recommend_by_papers(self.candidate_papers)
 
@@ -49,20 +50,20 @@ class TestRecommender(unittest.TestCase):
             sorted(recommendations, key=lambda x: x["score"], reverse=True), recommendations
         )
 
-    def test_recommend_by_papers_with_top_k(self):
+    def test_recommend_by_papers_with_top_k(self) -> None:
         """Test if top_k parameter limits the results correctly."""
         recommendations = self.recommender.recommend_by_papers(self.candidate_papers, top_k=2)
         self.assertEqual(len(recommendations), 2)
 
-    def test_recommend_by_papers_with_empty_candidates(self):
+    def test_recommend_by_papers_with_empty_candidates(self) -> None:
         """Test behavior when no candidate papers are provided."""
         recommendations = self.recommender.recommend_by_papers([])
         self.assertEqual(recommendations, [])
 
-    def test_init_raises_error_if_no_favorites(self):
+    def test_init_raises_error_if_no_favorites(self) -> None:
         """Test that an error is raised when no favorite papers are provided."""
         with self.assertRaises(ValueError):
-            Recommender(vectorizer=self.mock_vectorizer, favorite_papers=None)
+            Recommender(vectorizer=self.mock_vectorizer, favorite_papers=None)  # type: ignore[arg-type]
 
         with self.assertRaises(ValueError):
             Recommender(vectorizer=self.mock_vectorizer, favorite_papers=[])

--- a/tests/text_vectorization/test_distil_bert.py
+++ b/tests/text_vectorization/test_distil_bert.py
@@ -1,42 +1,25 @@
 import unittest
-from unittest.mock import patch, MagicMock
-import torch
-import numpy as np
+from typing import Any
+from unittest.mock import patch
 
 from arxiv_recommender.text_vectorization.distil_bert import DistilBERTEmbedding
+from arxiv_recommender.text_vectorization.huggingface_embed import HuggingFaceEmbedding
+from arxiv_recommender.text_vectorization import TextEmbedder
 
 
 class TestDistilBERTEmbedding(unittest.TestCase):
-    @patch("arxiv_recommender.text_vectorization.distil_bert.DistilBertModel.from_pretrained")
-    @patch("arxiv_recommender.text_vectorization.distil_bert.DistilBertTokenizer.from_pretrained")
-    def test_process_returns_expected_shape(
-        self, mock_tokenizer_from_pretrained, mock_model_from_pretrained
-    ):
-        # Mock the tokenizer
-        mock_tokenizer = MagicMock()
-        mock_tokenizer.return_value = {
-            "input_ids": torch.randint(0, 1000, (1, 512)),
-            "attention_mask": torch.ones(1, 512),
-        }
-        mock_tokenizer_from_pretrained.return_value = mock_tokenizer
-        # Mock the model
-        mock_model = MagicMock()
-        mock_output = MagicMock()
-        mock_output.last_hidden_state = torch.rand(1, 512, 768)  # (batch_size, seq_len, hidden_dim)
-        mock_model.return_value = mock_output
-        mock_model_from_pretrained.return_value = mock_model
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_distilbert_embedding_is_backward_compatible_wrapper(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        embedder = DistilBERTEmbedding()
 
-        # Instantiate and run
-        embedder = DistilBERTEmbedding("distilbert-base-uncased")
-        embedding = embedder.process("This is a sample input text.")
-
-        # Assertions
-        self.assertIsInstance(embedding, np.ndarray)
-        self.assertEqual(embedding.shape, (768,))  # After mean pooling
-
-        # Ensure model/tokenizer were called correctly
-        mock_tokenizer_from_pretrained.assert_called_once()
-        mock_model_from_pretrained.assert_called_once()
+        self.assertIsInstance(embedder, TextEmbedder)
+        self.assertIsInstance(embedder, HuggingFaceEmbedding)
+        self.assertEqual(embedder.model_name, "distilbert-base-uncased")
+        mock_tokenizer_from_pretrained.assert_called_once_with("distilbert-base-uncased")
+        mock_model_from_pretrained.assert_called_once_with("distilbert-base-uncased")
 
 
 if __name__ == "__main__":

--- a/tests/text_vectorization/test_huggingface_embed.py
+++ b/tests/text_vectorization/test_huggingface_embed.py
@@ -1,0 +1,67 @@
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import torch
+
+from arxiv_recommender.text_vectorization.huggingface_embed import HuggingFaceEmbedding
+
+
+class TestHuggingFaceEmbedding(unittest.TestCase):
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_process_returns_attention_masked_mean_embedding(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.tensor([[101, 102, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 0]]),
+        }
+        mock_tokenizer_from_pretrained.return_value = mock_tokenizer
+
+        mock_model = MagicMock()
+        mock_output = MagicMock()
+        mock_output.last_hidden_state = torch.tensor([[[1.0, 3.0], [3.0, 5.0], [100.0, 100.0]]])
+        mock_model.return_value = mock_output
+        mock_model_from_pretrained.return_value = mock_model
+
+        embedder = HuggingFaceEmbedding("test-model")
+        embedding = embedder.process("sample text")
+
+        self.assertIsInstance(embedding, np.ndarray)
+        np.testing.assert_array_equal(embedding, np.array([2.0, 4.0], dtype=np.float32))
+        mock_tokenizer_from_pretrained.assert_called_once_with("test-model")
+        mock_model_from_pretrained.assert_called_once_with("test-model")
+        mock_model.eval.assert_called_once()
+
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_process_uses_cache(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.tensor([[101]]),
+            "attention_mask": torch.tensor([[1]]),
+        }
+        mock_tokenizer_from_pretrained.return_value = mock_tokenizer
+
+        mock_model = MagicMock()
+        mock_output = MagicMock()
+        mock_output.last_hidden_state = torch.tensor([[[1.0, 2.0]]])
+        mock_model.return_value = mock_output
+        mock_model_from_pretrained.return_value = mock_model
+
+        embedder = HuggingFaceEmbedding("test-model")
+        first_embedding = embedder.process("same text")
+        second_embedding = embedder.process("same text")
+
+        np.testing.assert_array_equal(first_embedding, second_embedding)
+        mock_model.assert_called_once()
+        self.assertEqual(embedder.get_cache_stats()["hits"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -1,19 +1,40 @@
 import unittest
+from typing import Any
 from unittest.mock import patch
+
+import numpy as np
+
+from arxiv_recommender.text_vectorization import TextEmbedder
 from arxiv_recommender.utils.model_loader import load_vectorization_model
+
+
+class FakeEmbedder(TextEmbedder):
+    def process(self, text: str) -> np.ndarray:
+        return np.array([len(text)])
+
+    def get_cache_stats(self) -> dict[str, int]:
+        return {"hits": 0, "misses": 0}
+
+
+class NotEmbedder:
+    def __init__(self, model_name: str, cache_size: int) -> None:
+        self.model_name = model_name
+        self.cache_size = cache_size
 
 
 class TestModelLoader(unittest.TestCase):
     """Test cases for dynamic text vectorizer loading."""
 
     @patch("importlib.import_module")
-    def test_load_default_vectorizer(self, mock_import):
+    def test_load_default_vectorizer(self, mock_import: Any) -> None:
         """
         Test loading the default DistilBERTEmbedding vectorizer.
         """
         # Mock module and class
         mock_module = unittest.mock.MagicMock()
         mock_class = unittest.mock.MagicMock()
+        fake_embedder = FakeEmbedder()
+        mock_class.return_value = fake_embedder
         mock_module.DistilBERTEmbedding = mock_class
         mock_import.return_value = mock_module
 
@@ -28,15 +49,17 @@ class TestModelLoader(unittest.TestCase):
         mock_class.assert_called_once_with("distilbert-base-uncased", cache_size=1000)
 
         # Ensure instance is returned
-        self.assertEqual(vectorizer, mock_class())
+        self.assertEqual(vectorizer, fake_embedder)
 
     @patch("importlib.import_module")
-    def test_load_custom_vectorizer(self, mock_import):
+    def test_load_custom_vectorizer(self, mock_import: Any) -> None:
         """
         Test loading a custom text vectorization model dynamically.
         """
         mock_module = unittest.mock.MagicMock()
         mock_class = unittest.mock.MagicMock()
+        fake_embedder = FakeEmbedder()
+        mock_class.return_value = fake_embedder
         mock_module.CustomVectorizer = mock_class
         mock_import.return_value = mock_module
 
@@ -53,9 +76,9 @@ class TestModelLoader(unittest.TestCase):
         mock_class.assert_called_once_with("custom_vectorinzer_model_name", cache_size=1000)
 
         # Ensure instance is returned
-        self.assertEqual(vectorizer, mock_class())
+        self.assertEqual(vectorizer, fake_embedder)
 
-    def test_load_invalid_vectorizer(self):
+    def test_load_invalid_vectorizer(self) -> None:
         """
         Test behavior when an invalid vectorizer is specified.
         Expect ImportError to be raised.
@@ -64,6 +87,15 @@ class TestModelLoader(unittest.TestCase):
             load_vectorization_model(
                 "non_existent_module", "NonExistentModel", "non_existent_model", 1000
             )
+
+    @patch("importlib.import_module")
+    def test_load_rejects_non_text_embedder(self, mock_import: Any) -> None:
+        mock_module = unittest.mock.MagicMock()
+        mock_module.NotEmbedder = NotEmbedder
+        mock_import.return_value = mock_module
+
+        with self.assertRaises(ImportError):
+            load_vectorization_model("custom_vectorizer", "NotEmbedder", "model-name", 1000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a TextEmbedder interface and generic HuggingFaceEmbedding implementation
- keep DistilBERTEmbedding as a backward-compatible wrapper
- update recommender/model loader typing and validation around TextEmbedder
- update focused tests for the new abstraction and loader validation

## Tests
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest