### PR TITLE
fix: clarify arxiv fetcher error semantics

### DIFF
--- a/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
@@ -5,6 +5,10 @@ from arxiv_recommender.arxiv_paper_fetcher.utils import remove_control_character
 from arxiv_recommender.schemas import Paper
 
 
+class ArxivParseError(ValueError):
+    """Raised when an arXiv API response cannot be parsed as valid XML."""
+
+
 def extract_metadata(entry: ET.Element) -> Paper:
     """
     Extracts paper's meta data from a single XML entry.
@@ -52,8 +56,8 @@ def parse_paper_info(xml_data: str) -> Optional[Paper]:
         if entry is None:
             return None
         return extract_metadata(entry)
-    except ET.ParseError:
-        return None
+    except ET.ParseError as exc:
+        raise ArxivParseError("Malformed arXiv XML response.") from exc
 
 
 def parse_papers(xml_data: str) -> list[Paper]:
@@ -73,7 +77,7 @@ def parse_papers(xml_data: str) -> list[Paper]:
             if entry is None:
                 continue
             papers.append(extract_metadata(entry))
-    except ET.ParseError:
-        pass
+    except ET.ParseError as exc:
+        raise ArxivParseError("Malformed arXiv XML response.") from exc
 
     return papers

--- a/tests/arxiv_paper_fetcher/test_fetcher.py
+++ b/tests/arxiv_paper_fetcher/test_fetcher.py
@@ -1,58 +1,93 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+
 import requests
 from arxiv_recommender.arxiv_paper_fetcher.fetcher import ArxivFetcher
+from arxiv_recommender.arxiv_paper_fetcher.parser import ArxivParseError
 
 
 class TestArxivFetcher(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         """Initialize the ArxivFetcher instance for tests."""
         self.fetcher = ArxivFetcher(max_results=5)
 
-    @patch("requests.get")
-    def test_get_paper_by_id_success(self, mock_get):
-        """Test fetching a single paper successfully by ID."""
+    def _mock_response(self, text: str, status_code: int = 200) -> Mock:
+        """Create a response mock with realistic status handling."""
         mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+        mock_response.status_code = status_code
+        mock_response.text = text
+        mock_response.raise_for_status.return_value = None
+        return mock_response
+
+    @patch("requests.get")
+    def test_get_paper_by_id_success(self, mock_get: Mock) -> None:
+        """Test fetching a single paper successfully by ID."""
+        mock_response = self._mock_response("""<?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
             <entry>
                 <title>Sample Paper</title>
                 <summary>Sample Abstract</summary>
             </entry>
-        </feed>"""
+        </feed>""")
         mock_get.return_value = mock_response
 
         paper = self.fetcher.get_paper_by_id("1234.56789")
-        self.assertIsNotNone(paper)
+        assert paper is not None
         self.assertEqual(paper.title, "Sample Paper")
         self.assertEqual(paper.abstract, "Sample Abstract")
+        mock_response.raise_for_status.assert_called_once()
 
+    @patch("arxiv_recommender.utils.retry.time.sleep", return_value=None)
     @patch("requests.get")
-    def test_get_paper_by_id_failure(self, mock_get):
-        """Test handling of a failed paper fetch (e.g., paper not found)."""
-        mock_response = Mock()
-        mock_response.status_code = 404
-        mock_response.text = ""  # Empty response
+    def test_get_paper_by_id_http_error(self, mock_get: Mock, mock_sleep: Mock) -> None:
+        """Test HTTP errors raise after the retry policy is applied."""
+        mock_response = self._mock_response("", status_code=404)
+        mock_response.raise_for_status.side_effect = requests.HTTPError("404 Client Error")
         mock_get.return_value = mock_response
 
-        paper = self.fetcher.get_paper_by_id("non_existent_paper")
+        with self.assertRaises(requests.HTTPError):
+            self.fetcher.get_paper_by_id("non_existent_paper")
+
+        self.assertEqual(mock_get.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 3)
+
+    @patch("requests.get")
+    def test_get_paper_by_id_empty_feed_returns_none(self, mock_get: Mock) -> None:
+        """Test a successful empty feed returns None."""
+        mock_get.return_value = self._mock_response(
+            """<?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <!-- No entries -->
+        </feed>"""
+        )
+
+        paper = self.fetcher.get_paper_by_id("missing_paper")
         self.assertIsNone(paper)
 
     @patch("requests.get")
-    def test_get_paper_by_id_network_error(self, mock_get):
-        """Test handling of network errors when fetching a paper."""
+    def test_get_paper_by_id_malformed_xml_raises(self, mock_get: Mock) -> None:
+        """Test malformed XML raises an explicit parse error."""
+        mock_get.return_value = self._mock_response("<feed>")
+
+        with self.assertRaises(ArxivParseError):
+            self.fetcher.get_paper_by_id("1234.56789")
+
+    @patch("arxiv_recommender.utils.retry.time.sleep", return_value=None)
+    @patch("requests.get")
+    def test_get_paper_by_id_network_error(self, mock_get: Mock, mock_sleep: Mock) -> None:
+        """Test network errors raise after the retry policy is applied."""
         mock_get.side_effect = requests.RequestException("Network error")
 
         with self.assertRaises(requests.RequestException):
             self.fetcher.get_paper_by_id("1234.56789")
 
+        self.assertEqual(mock_get.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 3)
+
     @patch("requests.get")
-    def test_get_daily_papers_success(self, mock_get):
+    def test_get_daily_papers_success(self, mock_get: Mock) -> None:
         """Test fetching new daily papers successfully."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+        mock_response = self._mock_response("""<?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
             <entry>
                 <title>Paper 1</title>
@@ -62,35 +97,60 @@ class TestArxivFetcher(unittest.TestCase):
                 <title>Paper 2</title>
                 <summary>Abstract 2</summary>
             </entry>
-        </feed>"""
+        </feed>""")
         mock_get.return_value = mock_response
 
         papers = self.fetcher.get_daily_papers(category="cs.AI")
         self.assertEqual(len(papers), 2)
         self.assertEqual(papers[0].title, "Paper 1")
         self.assertEqual(papers[1].abstract, "Abstract 2")
+        mock_response.raise_for_status.assert_called_once()
 
     @patch("requests.get")
-    def test_get_daily_papers_no_results(self, mock_get):
+    def test_get_daily_papers_no_results(self, mock_get: Mock) -> None:
         """Test fetching daily papers when no new papers are available."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+        mock_response = self._mock_response("""<?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
             <!-- No entries -->
-        </feed>"""
+        </feed>""")
         mock_get.return_value = mock_response
 
         papers = self.fetcher.get_daily_papers(category="cs.LG")
         self.assertEqual(len(papers), 0)
 
     @patch("requests.get")
-    def test_get_daily_papers_network_error(self, mock_get):
-        """Test handling of network errors when fetching daily papers."""
+    def test_get_daily_papers_malformed_xml_raises(self, mock_get: Mock) -> None:
+        """Test malformed XML raises an explicit parse error."""
+        mock_get.return_value = self._mock_response("<feed>")
+
+        with self.assertRaises(ArxivParseError):
+            self.fetcher.get_daily_papers(category="cs.LG")
+
+    @patch("arxiv_recommender.utils.retry.time.sleep", return_value=None)
+    @patch("requests.get")
+    def test_get_daily_papers_http_error(self, mock_get: Mock, mock_sleep: Mock) -> None:
+        """Test HTTP errors raise after the retry policy is applied."""
+        mock_response = self._mock_response("", status_code=500)
+        mock_response.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(requests.HTTPError):
+            self.fetcher.get_daily_papers(category="cs.LG")
+
+        self.assertEqual(mock_get.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 3)
+
+    @patch("arxiv_recommender.utils.retry.time.sleep", return_value=None)
+    @patch("requests.get")
+    def test_get_daily_papers_network_error(self, mock_get: Mock, mock_sleep: Mock) -> None:
+        """Test network errors raise after the retry policy is applied."""
         mock_get.side_effect = requests.RequestException("API timeout")
 
         with self.assertRaises(requests.RequestException):
             self.fetcher.get_daily_papers(category="cs.LG")
+
+        self.assertEqual(mock_get.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 3)
 
 
 if __name__ == "__main__":

--- a/tests/arxiv_paper_fetcher/test_parser.py
+++ b/tests/arxiv_paper_fetcher/test_parser.py
@@ -1,6 +1,7 @@
 import unittest
 import xml.etree.ElementTree as ET
 from arxiv_recommender.arxiv_paper_fetcher.parser import (
+    ArxivParseError,
     extract_metadata,
     parse_paper_info,
     parse_papers,
@@ -8,7 +9,7 @@ from arxiv_recommender.arxiv_paper_fetcher.parser import (
 
 
 class TestParser(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test XML responses"""
         self.sample_entry = """
         <feed xmlns="http://www.w3.org/2005/Atom">
@@ -32,26 +33,48 @@ class TestParser(unittest.TestCase):
         </feed>
         """
 
-    def test_extract_metadata(self):
+    def test_extract_metadata(self) -> None:
         """Test extracting metadata from a single entry"""
         root = ET.fromstring(self.sample_entry)
         entry = root.find("{http://www.w3.org/2005/Atom}entry")
+        assert entry is not None
         metadata = extract_metadata(entry)
         self.assertEqual(metadata.title, "Sample Paper")
         self.assertEqual(metadata.abstract, "Sample Abstract")
 
-    def test_parse_paper_info(self):
+    def test_parse_paper_info(self) -> None:
         """Test extracting title and abstract from a single entry"""
         paper = parse_paper_info(self.sample_entry)
+        assert paper is not None
         self.assertEqual(paper.title, "Sample Paper")
         self.assertEqual(paper.abstract, "Sample Abstract")
 
-    def test_parse_papers(self):
+    def test_parse_paper_info_empty_feed_returns_none(self) -> None:
+        """Test parsing a valid feed with no entry returns None."""
+        paper = parse_paper_info('<feed xmlns="http://www.w3.org/2005/Atom"></feed>')
+        self.assertIsNone(paper)
+
+    def test_parse_paper_info_malformed_xml_raises(self) -> None:
+        """Test malformed XML raises an explicit parse error."""
+        with self.assertRaises(ArxivParseError):
+            parse_paper_info("<feed>")
+
+    def test_parse_papers(self) -> None:
         """Test extracting multiple papers from a feed"""
         papers = parse_papers(self.sample_feed)
         self.assertEqual(len(papers), 2)
         self.assertEqual(papers[0].title, "Paper 1")
         self.assertEqual(papers[1].abstract, "Abstract 2")
+
+    def test_parse_papers_empty_feed_returns_empty_list(self) -> None:
+        """Test parsing a valid feed with no entries returns an empty list."""
+        papers = parse_papers('<feed xmlns="http://www.w3.org/2005/Atom"></feed>')
+        self.assertEqual(papers, [])
+
+    def test_parse_papers_malformed_xml_raises(self) -> None:
+        """Test malformed XML raises an explicit parse error."""
+        with self.assertRaises(ArxivParseError):
+            parse_papers("<feed>")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make malformed arXiv XML raise an explicit ArxivParseError
- update fetcher tests to use realistic raise_for_status mocks
- distinguish valid empty feeds from HTTP and network failures, including retry assertions without real sleep

Closes #27

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest