### PR TITLE
fix: validate configuration and vectorizer loading

### DIFF
--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -3,6 +3,7 @@
 Objective review of the current `arxiv_recommender` codebase, focused on correctness, maintainability, ML quality, testing, and operational readiness.
 
 - Reviewed on: 2026-05-25
+- Updated on: 2026-05-31 after PR #30
 - Scope: current codebase snapshot
 - Context: local CLI or localhost app priority
 
@@ -13,7 +14,7 @@ This document is a review snapshot, not a final verdict. Priority should follow 
 - `uv run ruff check .`: passed.
 - `uv run ruff format --check .`: passed.
 - `uv run python -m mypy src`: passed.
-- `uv run python -m pytest`: passed, 82 tests.
+- `uv run python -m pytest`: passed, 100 tests.
 
 ## Priority Findings
 
@@ -52,20 +53,24 @@ Relevant code:
 - `src/arxiv_recommender/text_vectorization/base.py`
 - `src/arxiv_recommender/text_vectorization/huggingface_embed.py`
 
-### High: Fetcher Tests Contain False Positives
+### Resolved: Fetcher Tests Contained False Positives
 
 `ArxivFetcher` calls `response.raise_for_status()`, so real HTTP 404 responses should raise. Some tests expect `None` because the mock response does not configure `raise_for_status`, which means the test does not reflect production behavior.
 
-Recommended improvements:
+Status:
 
-- Configure mocked responses with realistic `raise_for_status` behavior.
-- Decide whether 404 should raise or return `None`, then encode that behavior explicitly.
-- Add tests for HTTP errors, malformed XML, empty feeds, and retry behavior.
+- Resolved by PR #29, `fix: clarify arxiv fetcher error semantics`.
+- Mocked responses now configure `raise_for_status` explicitly.
+- HTTP failures raise `requests` exceptions after retry behavior is applied.
+- Valid empty feeds remain distinct from failures: `get_paper_by_id()` returns `None`, and `get_daily_papers()` returns `[]`.
+- Malformed arXiv XML now raises `ArxivParseError` instead of being treated as an empty result.
 
 Relevant code:
 
 - `src/arxiv_recommender/arxiv_paper_fetcher/fetcher.py`
+- `src/arxiv_recommender/arxiv_paper_fetcher/parser.py`
 - `tests/arxiv_paper_fetcher/test_fetcher.py`
+- `tests/arxiv_paper_fetcher/test_parser.py`
 
 ### Medium: Metrics Are Partially Unwired
 
@@ -104,20 +109,31 @@ Relevant code:
 
 ### Medium: Config Validation Is Too Permissive
 
-Pydantic models are used, but they do not yet enforce important domain constraints. Invalid values such as empty model names, negative `top_k`, invalid cache size, or invalid log levels can pass validation.
+Pydantic models are used, and PR #30 tightened deterministic scalar constraints while adding runtime validation for environment-dependent vectorizer settings.
 
-Recommended improvements:
+Status:
 
-- Enforce `top_k > 0`.
-- Enforce `cache_size >= 0` or `cache_size > 0`, depending on desired behavior.
-- Restrict `log_level` to known logging levels.
-- Reject empty module/class/model names.
-- Add tests for invalid config values.
+- Partially addressed by PR #30, `fix: validate configuration and vectorizer loading`.
+- `top_k > 0` is enforced.
+- `cache_size >= 0` is enforced, allowing zero to disable caching.
+- `log_level` is normalized and restricted to known logging levels.
+- CLI log-level choices and logging setup reuse the same supported-level constant.
+- Invalid vectorizer modules, classes, dependencies, and model-instantiation failures now raise actionable `VectorizationModelLoadError` messages.
+
+Design decision:
+
+- `module_name`, `class_name`, and `model_name` are validated when the vectorizer is loaded instead of using schema-level non-empty-string checks.
+- Non-empty-string checks would reject only one trivial failure mode while arbitrary invalid names would still fail later.
+- Runtime validation can distinguish missing modules, missing classes, missing dependencies, and model-instantiation failures and return actionable errors.
 
 Relevant code:
 
 - `src/arxiv_recommender/schemas/config.py`
+- `src/arxiv_recommender/utils/logging.py`
+- `src/arxiv_recommender/utils/model_loader.py`
 - `tests/schemas/test_config.py`
+- `tests/utils/test_logging.py`
+- `tests/utils/test_model_loader.py`
 
 ### Medium: arXiv Query Construction Is Brittle
 
@@ -158,10 +174,10 @@ Relevant files:
 
 The following order is recommended if the immediate goal is a usable local CLI app or a web app served on `localhost`.
 
-1. Fix fetcher test realism and clarify HTTP error behavior.
-2. Tighten Pydantic validation for config and paper data.
-3. Add structured paper identity fields and recommendation output models.
-4. Add a lightweight retrieval quality evaluation harness.
+1. Add structured paper identity fields and recommendation output models.
+2. Complete remaining schema validation for paper data and request inputs.
+3. Add a lightweight retrieval quality evaluation harness.
+4. Improve CLI error reporting for fetcher and parser failures.
 5. Improve the CLI workflow or build a thin localhost web UI.
 6. Wire metrics fully or simplify them to only report trustworthy values.
 7. Add batch embedding support and benchmark latency.

--- a/src/arxiv_recommender/cli.py
+++ b/src/arxiv_recommender/cli.py
@@ -8,6 +8,7 @@ from arxiv_recommender.recommendation import RecommendationPipeline
 from arxiv_recommender.schemas import AppConfig
 from arxiv_recommender.utils import MetricsCollector, setup_logging
 from arxiv_recommender.utils.json_handler import load_json
+from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
 from arxiv_recommender.utils.model_loader import load_vectorization_model
 
 
@@ -45,9 +46,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--log-level",
-        type=str,
+        type=str.upper,
+        choices=SUPPORTED_LOG_LEVELS,
         default=None,
-        help="Override log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).",
+        help=f"Override log level ({', '.join(SUPPORTED_LOG_LEVELS)}).",
     )
     parser.add_argument(
         "--stats",

--- a/src/arxiv_recommender/schemas/config.py
+++ b/src/arxiv_recommender/schemas/config.py
@@ -1,11 +1,17 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
 
 
 class VectorizerConfig(BaseModel):
     module_name: str = Field(description="Module name for the vectorizer")
     class_name: str = Field(description="Class name for the vectorizer")
     model_name: str = Field(description="Path or name of the model")
-    cache_size: int = Field(default=1000, description="Maximum number of embeddings to cache")
+    cache_size: int = Field(
+        default=1000,
+        ge=0,
+        description="Maximum number of embeddings to cache",
+    )
 
     model_config = {"frozen": True}
 
@@ -13,9 +19,18 @@ class VectorizerConfig(BaseModel):
 class AppConfig(BaseModel):
     favorite_papers_path: str = Field(description="Path to the favorite papers JSON file")
     vectorizer: VectorizerConfig = Field(description="Vectorizer configuration")
-    top_k: int = Field(default=10, description="Number of top recommendations to return")
+    top_k: int = Field(default=10, gt=0, description="Number of top recommendations to return")
     log_level: str = Field(
-        default="INFO", description="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"
+        default="INFO",
+        description=f"Logging level ({', '.join(SUPPORTED_LOG_LEVELS)})",
     )
+
+    @field_validator("log_level")
+    @classmethod
+    def validate_log_level(cls, value: str) -> str:
+        normalized_value = value.upper()
+        if normalized_value not in SUPPORTED_LOG_LEVELS:
+            raise ValueError(f"log_level must be one of: {', '.join(SUPPORTED_LOG_LEVELS)}")
+        return normalized_value
 
     model_config = {"frozen": True}

--- a/src/arxiv_recommender/utils/__init__.py
+++ b/src/arxiv_recommender/utils/__init__.py
@@ -1,10 +1,11 @@
 """Utilities for arxiv_recommender."""
 
-from arxiv_recommender.utils.logging import JSONFormatter, setup_logging
+from arxiv_recommender.utils.logging import JSONFormatter, SUPPORTED_LOG_LEVELS, setup_logging
 from arxiv_recommender.utils.metrics import MetricsCollector
 
 __all__ = [
     "JSONFormatter",
-    "setup_logging",
     "MetricsCollector",
+    "SUPPORTED_LOG_LEVELS",
+    "setup_logging",
 ]

--- a/src/arxiv_recommender/utils/logging.py
+++ b/src/arxiv_recommender/utils/logging.py
@@ -16,6 +16,10 @@ import json
 import logging
 import sys
 from datetime import datetime, timezone
+from typing import Final
+
+
+SUPPORTED_LOG_LEVELS: Final = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 
 
 class JSONFormatter(logging.Formatter):
@@ -73,7 +77,13 @@ def setup_logging(level: str = "INFO", json_format: bool = True) -> None:
             If False, output human-readable format (for development).
             Default is True.
     """
-    log_level = getattr(logging, level.upper(), logging.INFO)
+    normalized_level = level.upper()
+    if normalized_level not in SUPPORTED_LOG_LEVELS:
+        raise ValueError(
+            f"Unsupported log level '{level}'. Expected one of: {', '.join(SUPPORTED_LOG_LEVELS)}."
+        )
+
+    log_level = getattr(logging, normalized_level)
     handler = logging.StreamHandler(sys.stdout)
 
     if json_format:

--- a/src/arxiv_recommender/utils/model_loader.py
+++ b/src/arxiv_recommender/utils/model_loader.py
@@ -1,7 +1,13 @@
 import importlib
 import logging
+from types import ModuleType
+from typing import Any
 
 from arxiv_recommender.text_vectorization import TextEmbedder
+
+
+class VectorizationModelLoadError(ImportError):
+    """Raised when a configured vectorization model cannot be loaded."""
 
 
 def load_vectorization_model(
@@ -23,20 +29,79 @@ def load_vectorization_model(
         Instantiated text embedder.
 
     Raises:
-        ImportError: If the model class is not found.
+        VectorizationModelLoadError: If the configured model cannot be loaded.
     """
+    full_module_name = f"arxiv_recommender.text_vectorization.{module_name}"
+
     try:
-        module = importlib.import_module(f"arxiv_recommender.text_vectorization.{module_name}")
-        model_class = getattr(module, class_name)
+        module = importlib.import_module(full_module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == full_module_name:
+            logging.error("Vectorizer module '%s' was not found.", full_module_name)
+            raise VectorizationModelLoadError(
+                f"Vectorizer module '{full_module_name}' was not found."
+            ) from exc
+
+        logging.error(
+            "Vectorizer module '%s' could not be imported because dependency '%s' was not found.",
+            full_module_name,
+            exc.name,
+        )
+        raise VectorizationModelLoadError(
+            f"Vectorizer module '{full_module_name}' could not be imported because dependency "
+            f"'{exc.name}' was not found."
+        ) from exc
+
+    model_class = _get_vectorizer_class(module, class_name, full_module_name)
+
+    try:
         model = model_class(model_name, cache_size=cache_size)
-        if not isinstance(model, TextEmbedder):
-            logging.error(
-                "Invalid vectorization model '%s.%s': not a TextEmbedder",
-                module_name,
-                class_name,
-            )
-            raise ImportError(f"Model '{module_name}.{class_name}' is not a TextEmbedder.")
-        return model
-    except (ModuleNotFoundError, AttributeError) as e:
-        logging.error("Failed to load vectorization model '%s.%s': %s", module_name, class_name, e)
-        raise ImportError(f"Model '{module_name}.{class_name}' not found.")
+    except Exception as exc:
+        logging.error(
+            "Failed to instantiate vectorizer '%s.%s' with model '%s': %s",
+            full_module_name,
+            class_name,
+            model_name,
+            exc,
+        )
+        raise VectorizationModelLoadError(
+            f"Failed to instantiate vectorizer '{full_module_name}.{class_name}' "
+            f"with model '{model_name}'."
+        ) from exc
+
+    if not isinstance(model, TextEmbedder):
+        logging.error(
+            "Invalid vectorization model '%s.%s': instance is not a TextEmbedder",
+            full_module_name,
+            class_name,
+        )
+        raise VectorizationModelLoadError(
+            f"Vectorizer '{full_module_name}.{class_name}' must create a TextEmbedder."
+        )
+
+    return model
+
+
+def _get_vectorizer_class(
+    module: ModuleType,
+    class_name: str,
+    full_module_name: str,
+) -> Any:
+    model_class = getattr(module, class_name, None)
+    if model_class is None:
+        logging.error("Vectorizer class '%s' was not found in '%s'.", class_name, full_module_name)
+        raise VectorizationModelLoadError(
+            f"Vectorizer class '{class_name}' was not found in module '{full_module_name}'."
+        )
+
+    if not isinstance(model_class, type) or not issubclass(model_class, TextEmbedder):
+        logging.error(
+            "Invalid vectorizer class '%s.%s': not a TextEmbedder subclass.",
+            full_module_name,
+            class_name,
+        )
+        raise VectorizationModelLoadError(
+            f"Vectorizer class '{full_module_name}.{class_name}' must inherit from TextEmbedder."
+        )
+
+    return model_class

--- a/tests/schemas/test_config.py
+++ b/tests/schemas/test_config.py
@@ -5,7 +5,7 @@ from arxiv_recommender.schemas.config import AppConfig, VectorizerConfig
 class TestVectorizerConfig:
     """Tests for VectorizerConfig schema."""
 
-    def test_create_vectorizer_config(self):
+    def test_create_vectorizer_config(self) -> None:
         """Test creating VectorizerConfig with valid data."""
         config = VectorizerConfig(
             module_name="distil_bert",
@@ -16,7 +16,7 @@ class TestVectorizerConfig:
         assert config.class_name == "DistilBERTEmbedding"
         assert config.model_name == "distilbert-base-uncased"
 
-    def test_vectorizer_is_frozen(self):
+    def test_vectorizer_is_frozen(self) -> None:
         """Test that VectorizerConfig is immutable."""
         config = VectorizerConfig(
             module_name="test", class_name="TestClass", model_name="test-model"
@@ -24,7 +24,7 @@ class TestVectorizerConfig:
         with pytest.raises(Exception):
             config.module_name = "new_module"
 
-    def test_vectorizer_serialization(self):
+    def test_vectorizer_serialization(self) -> None:
         """Test VectorizerConfig can be serialized to dict."""
         config = VectorizerConfig(
             module_name="test", class_name="TestClass", model_name="test-model"
@@ -34,11 +34,31 @@ class TestVectorizerConfig:
         assert data["class_name"] == "TestClass"
         assert data["model_name"] == "test-model"
 
+    def test_vectorizer_rejects_negative_cache_size(self) -> None:
+        """Test that cache_size cannot be negative."""
+        with pytest.raises(Exception):
+            VectorizerConfig(
+                module_name="test",
+                class_name="TestClass",
+                model_name="test-model",
+                cache_size=-1,
+            )
+
+    def test_vectorizer_allows_zero_cache_size(self) -> None:
+        """Test that cache_size can be zero to disable caching."""
+        config = VectorizerConfig(
+            module_name="test",
+            class_name="TestClass",
+            model_name="test-model",
+            cache_size=0,
+        )
+        assert config.cache_size == 0
+
 
 class TestAppConfig:
     """Tests for AppConfig schema."""
 
-    def test_create_app_config(self):
+    def test_create_app_config(self) -> None:
         """Test creating AppConfig with valid data."""
         config = AppConfig(
             favorite_papers_path="favorite_papers.json",
@@ -53,7 +73,7 @@ class TestAppConfig:
         assert config.top_k == 10
         assert config.vectorizer.module_name == "distil_bert"
 
-    def test_app_config_default_top_k(self):
+    def test_app_config_default_top_k(self) -> None:
         """Test that top_k defaults to 10."""
         config = AppConfig(
             favorite_papers_path="favorites.json",
@@ -63,7 +83,7 @@ class TestAppConfig:
         )
         assert config.top_k == 10
 
-    def test_app_config_custom_top_k(self):
+    def test_app_config_custom_top_k(self) -> None:
         """Test custom top_k value."""
         config = AppConfig(
             favorite_papers_path="favorites.json",
@@ -74,7 +94,7 @@ class TestAppConfig:
         )
         assert config.top_k == 5
 
-    def test_app_config_is_frozen(self):
+    def test_app_config_is_frozen(self) -> None:
         """Test that AppConfig is immutable."""
         config = AppConfig(
             favorite_papers_path="favorites.json",
@@ -85,7 +105,7 @@ class TestAppConfig:
         with pytest.raises(Exception):
             config.top_k = 20
 
-    def test_app_config_serialization(self):
+    def test_app_config_serialization(self) -> None:
         """Test AppConfig can be serialized to dict."""
         config = AppConfig(
             favorite_papers_path="favorites.json",
@@ -99,7 +119,7 @@ class TestAppConfig:
         assert data["top_k"] == 5
         assert data["vectorizer"]["module_name"] == "test"
 
-    def test_app_config_from_json_dict(self):
+    def test_app_config_from_json_dict(self) -> None:
         """Test creating AppConfig from JSON-sourced dict."""
         data = {
             "favorite_papers_path": "my_favorites.json",
@@ -115,7 +135,41 @@ class TestAppConfig:
         assert config.top_k == 20
         assert config.vectorizer.model_name == "bert-base"
 
-    def test_app_config_required_fields(self):
+    def test_app_config_required_fields(self) -> None:
         """Test that required fields are enforced."""
         with pytest.raises(Exception):
-            AppConfig()
+            AppConfig.model_validate({})
+
+    @pytest.mark.parametrize("top_k", [0, -1])
+    def test_app_config_rejects_non_positive_top_k(self, top_k: int) -> None:
+        """Test that top_k must be positive."""
+        with pytest.raises(Exception):
+            AppConfig(
+                favorite_papers_path="favorites.json",
+                vectorizer=VectorizerConfig(
+                    module_name="test", class_name="TestClass", model_name="test"
+                ),
+                top_k=top_k,
+            )
+
+    def test_app_config_rejects_invalid_log_level(self) -> None:
+        """Test that log_level must be a supported logging level."""
+        with pytest.raises(Exception):
+            AppConfig(
+                favorite_papers_path="favorites.json",
+                vectorizer=VectorizerConfig(
+                    module_name="test", class_name="TestClass", model_name="test"
+                ),
+                log_level="LOUD",
+            )
+
+    def test_app_config_normalizes_log_level(self) -> None:
+        """Test that lowercase log_level values are normalized."""
+        config = AppConfig(
+            favorite_papers_path="favorites.json",
+            vectorizer=VectorizerConfig(
+                module_name="test", class_name="TestClass", model_name="test"
+            ),
+            log_level="debug",
+        )
+        assert config.log_level == "DEBUG"

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -2,7 +2,7 @@ import json
 import logging
 import unittest
 
-from arxiv_recommender.utils.logging import JSONFormatter, SUPPORTED_LOG_LEVELS, setup_logging
+from arxiv_recommender.utils.logging import JSONFormatter, setup_logging
 
 
 class TestJSONFormatter(unittest.TestCase):
@@ -73,13 +73,6 @@ class TestSetupLogging(unittest.TestCase):
         """Test that unsupported log levels raise a clear error."""
         with self.assertRaises(ValueError):
             setup_logging(level="LOUD", json_format=False)
-
-    def test_supported_log_levels_are_ordered(self) -> None:
-        """Test supported log levels remain deterministic for CLI choices and messages."""
-        self.assertEqual(
-            SUPPORTED_LOG_LEVELS,
-            ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -2,7 +2,7 @@ import json
 import logging
 import unittest
 
-from arxiv_recommender.utils.logging import JSONFormatter, setup_logging
+from arxiv_recommender.utils.logging import JSONFormatter, SUPPORTED_LOG_LEVELS, setup_logging
 
 
 class TestJSONFormatter(unittest.TestCase):
@@ -68,6 +68,18 @@ class TestSetupLogging(unittest.TestCase):
         setup_logging(level="INFO", json_format=False)
         self.assertTrue(logging.getLogger("urllib3").level >= logging.WARNING)
         self.assertTrue(logging.getLogger("requests").level >= logging.WARNING)
+
+    def test_setup_logging_rejects_invalid_level(self) -> None:
+        """Test that unsupported log levels raise a clear error."""
+        with self.assertRaises(ValueError):
+            setup_logging(level="LOUD", json_format=False)
+
+    def test_supported_log_levels_are_ordered(self) -> None:
+        """Test supported log levels remain deterministic for CLI choices and messages."""
+        self.assertEqual(
+            SUPPORTED_LOG_LEVELS,
+            ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -1,14 +1,33 @@
 import unittest
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 
 import numpy as np
 
 from arxiv_recommender.text_vectorization import TextEmbedder
-from arxiv_recommender.utils.model_loader import load_vectorization_model
+from arxiv_recommender.utils.model_loader import (
+    VectorizationModelLoadError,
+    load_vectorization_model,
+)
 
 
 class FakeEmbedder(TextEmbedder):
+    def __init__(self, model_name: str, cache_size: int) -> None:
+        self.model_name = model_name
+        self.cache_size = cache_size
+
+    def process(self, text: str) -> np.ndarray:
+        return np.array([len(text)])
+
+    def get_cache_stats(self) -> dict[str, int]:
+        return {"hits": 0, "misses": 0}
+
+
+class BrokenEmbedder(TextEmbedder):
+    def __init__(self, model_name: str, cache_size: int) -> None:
+        raise ValueError("model cannot be loaded")
+
     def process(self, text: str) -> np.ndarray:
         return np.array([len(text)])
 
@@ -30,72 +49,85 @@ class TestModelLoader(unittest.TestCase):
         """
         Test loading the default DistilBERTEmbedding vectorizer.
         """
-        # Mock module and class
-        mock_module = unittest.mock.MagicMock()
-        mock_class = unittest.mock.MagicMock()
-        fake_embedder = FakeEmbedder()
-        mock_class.return_value = fake_embedder
-        mock_module.DistilBERTEmbedding = mock_class
+        mock_module = SimpleNamespace(DistilBERTEmbedding=FakeEmbedder)
         mock_import.return_value = mock_module
 
-        # Load default vectorizer
         vectorizer = load_vectorization_model(
             "distil_bert", "DistilBERTEmbedding", "distilbert-base-uncased", 1000
         )
 
-        # Ensure the correct module was loaded
         mock_import.assert_called_once_with("arxiv_recommender.text_vectorization.distil_bert")
-        # Ensure the correct class was instantiated with cache_size
-        mock_class.assert_called_once_with("distilbert-base-uncased", cache_size=1000)
-
-        # Ensure instance is returned
-        self.assertEqual(vectorizer, fake_embedder)
+        self.assertIsInstance(vectorizer, FakeEmbedder)
+        fake_vectorizer = cast(FakeEmbedder, vectorizer)
+        self.assertEqual(fake_vectorizer.model_name, "distilbert-base-uncased")
+        self.assertEqual(fake_vectorizer.cache_size, 1000)
 
     @patch("importlib.import_module")
     def test_load_custom_vectorizer(self, mock_import: Any) -> None:
         """
         Test loading a custom text vectorization model dynamically.
         """
-        mock_module = unittest.mock.MagicMock()
-        mock_class = unittest.mock.MagicMock()
-        fake_embedder = FakeEmbedder()
-        mock_class.return_value = fake_embedder
-        mock_module.CustomVectorizer = mock_class
+        mock_module = SimpleNamespace(CustomVectorizer=FakeEmbedder)
         mock_import.return_value = mock_module
 
-        # Load a custom vectorizer
         vectorizer = load_vectorization_model(
             "custom_vectorizer", "CustomVectorizer", "custom_vectorinzer_model_name", 1000
         )
 
-        # Ensure the correct module was loaded
         mock_import.assert_called_once_with(
             "arxiv_recommender.text_vectorization.custom_vectorizer"
         )
-        # Ensure the correct class was instantiated with cache_size
-        mock_class.assert_called_once_with("custom_vectorinzer_model_name", cache_size=1000)
+        self.assertIsInstance(vectorizer, FakeEmbedder)
+        fake_vectorizer = cast(FakeEmbedder, vectorizer)
+        self.assertEqual(fake_vectorizer.model_name, "custom_vectorinzer_model_name")
+        self.assertEqual(fake_vectorizer.cache_size, 1000)
 
-        # Ensure instance is returned
-        self.assertEqual(vectorizer, fake_embedder)
+    @patch("importlib.import_module")
+    def test_load_missing_vectorizer_module(self, mock_import: Any) -> None:
+        full_module_name = "arxiv_recommender.text_vectorization.non_existent_module"
+        mock_import.side_effect = ModuleNotFoundError(
+            f"No module named '{full_module_name}'",
+            name=full_module_name,
+        )
 
-    def test_load_invalid_vectorizer(self) -> None:
-        """
-        Test behavior when an invalid vectorizer is specified.
-        Expect ImportError to be raised.
-        """
-        with self.assertRaises(ImportError):
+        with self.assertRaisesRegex(VectorizationModelLoadError, "module .* was not found"):
             load_vectorization_model(
                 "non_existent_module", "NonExistentModel", "non_existent_model", 1000
             )
 
     @patch("importlib.import_module")
-    def test_load_rejects_non_text_embedder(self, mock_import: Any) -> None:
-        mock_module = unittest.mock.MagicMock()
-        mock_module.NotEmbedder = NotEmbedder
-        mock_import.return_value = mock_module
+    def test_load_reports_missing_vectorizer_dependency(self, mock_import: Any) -> None:
+        mock_import.side_effect = ModuleNotFoundError(
+            "No module named 'transformers'",
+            name="transformers",
+        )
 
-        with self.assertRaises(ImportError):
+        with self.assertRaisesRegex(VectorizationModelLoadError, "dependency 'transformers'"):
+            load_vectorization_model("broken_module", "BrokenVectorizer", "broken-model", 1000)
+
+    @patch("importlib.import_module")
+    def test_load_missing_vectorizer_class(self, mock_import: Any) -> None:
+        mock_import.return_value = SimpleNamespace()
+
+        with self.assertRaisesRegex(VectorizationModelLoadError, "class 'MissingEmbedder'"):
+            load_vectorization_model("custom_vectorizer", "MissingEmbedder", "model-name", 1000)
+
+    @patch("importlib.import_module")
+    def test_load_rejects_non_text_embedder(self, mock_import: Any) -> None:
+        mock_import.return_value = SimpleNamespace(NotEmbedder=NotEmbedder)
+
+        with self.assertRaisesRegex(VectorizationModelLoadError, "must inherit from TextEmbedder"):
             load_vectorization_model("custom_vectorizer", "NotEmbedder", "model-name", 1000)
+
+    @patch("importlib.import_module")
+    def test_load_reports_model_instantiation_failure(self, mock_import: Any) -> None:
+        mock_import.return_value = SimpleNamespace(BrokenEmbedder=BrokenEmbedder)
+
+        with self.assertRaisesRegex(
+            VectorizationModelLoadError,
+            "Failed to instantiate vectorizer .* with model 'bad-model'",
+        ):
+            load_vectorization_model("custom_vectorizer", "BrokenEmbedder", "bad-model", 1000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add shared supported log-level validation for config, CLI, and logging setup
- enforce scalar config constraints for top_k and cache_size
- reject unsupported log levels instead of silently falling back to INFO
- add clearer vectorizer loading errors for missing modules, missing classes, missing dependencies, invalid classes, and model instantiation failures

## Issue
Part of #28.

This PR covers the config and vectorizer-loading validation portion. The paper metadata and typed recommendation model work should follow in a separate PR.

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest