### PR TITLE
feat: add structured paper metadata and typed recommendations

### DIFF
--- a/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
@@ -1,12 +1,36 @@
 import xml.etree.ElementTree as ET
+from datetime import datetime
 from typing import Optional
 
 from arxiv_recommender.arxiv_paper_fetcher.utils import remove_control_characters
 from arxiv_recommender.schemas import Paper
 
+ATOM_NAMESPACE = "{http://www.w3.org/2005/Atom}"
+
 
 class ArxivParseError(ValueError):
     """Raised when an arXiv API response cannot be parsed as valid XML."""
+
+
+def _get_text(entry: ET.Element, field: str) -> str:
+    """Return normalized text for an Atom child element."""
+    element = entry.find(f"{ATOM_NAMESPACE}{field}")
+    return (
+        remove_control_characters(element.text.strip())
+        if element is not None and element.text
+        else ""
+    )
+
+
+def _extract_arxiv_id(url: str) -> str:
+    """Extract an arXiv identifier from the canonical entry URL."""
+    return url.rsplit("/abs/", maxsplit=1)[-1]
+
+
+def _get_datetime(entry: ET.Element, field: str) -> datetime | None:
+    """Return an Atom timestamp as a datetime when present."""
+    value = _get_text(entry, field)
+    return datetime.fromisoformat(value) if value else None
 
 
 def extract_metadata(entry: ET.Element) -> Paper:
@@ -17,27 +41,35 @@ def extract_metadata(entry: ET.Element) -> Paper:
         entry (ET.Element): An XML element representing a paper entry.
 
     Returns:
-        Paper: A Paper object containing 'title' and 'abstract'.
+        Paper: A Paper object containing the available arXiv metadata.
     """
-    title_elem = entry.find("{http://www.w3.org/2005/Atom}title")
-    summary_elem = entry.find("{http://www.w3.org/2005/Atom}summary")
-    title = (
-        remove_control_characters(title_elem.text.strip())
-        if title_elem is not None and title_elem.text
-        else ""
-    )
-    abstract = (
-        remove_control_characters(summary_elem.text.strip())
-        if summary_elem is not None and summary_elem.text
-        else ""
-    )
+    url = _get_text(entry, "id")
+    title = _get_text(entry, "title")
+    abstract = _get_text(entry, "summary")
+    authors = [
+        name
+        for author in entry.findall(f"{ATOM_NAMESPACE}author")
+        if (name := _get_text(author, "name"))
+    ]
+    categories = [
+        term
+        for category in entry.findall(f"{ATOM_NAMESPACE}category")
+        if (term := category.get("term"))
+    ]
 
     if not title or not abstract:
         raise ValueError("Title or abstract is empty in the entry.")
-    if not isinstance(title, str) or not isinstance(abstract, str):
-        raise TypeError("Title or abstract is not a string in the entry.")
 
-    return Paper(title=title, abstract=abstract)
+    return Paper(
+        arxiv_id=_extract_arxiv_id(url) if url else None,
+        url=url or None,
+        title=title,
+        abstract=abstract,
+        authors=authors,
+        categories=categories,
+        published=_get_datetime(entry, "published"),
+        updated=_get_datetime(entry, "updated"),
+    )
 
 
 def parse_paper_info(xml_data: str) -> Optional[Paper]:
@@ -48,11 +80,11 @@ def parse_paper_info(xml_data: str) -> Optional[Paper]:
         xml_data (str): The XML response from arXiv API.
 
     Returns:
-        Optional[Paper]: A Paper object containing 'title' and 'abstract' if successful, else None.
+        Optional[Paper]: A Paper object containing available metadata if successful, else None.
     """
     try:
         root = ET.fromstring(xml_data)
-        entry = root.find("{http://www.w3.org/2005/Atom}entry")
+        entry = root.find(f"{ATOM_NAMESPACE}entry")
         if entry is None:
             return None
         return extract_metadata(entry)
@@ -68,12 +100,12 @@ def parse_papers(xml_data: str) -> list[Paper]:
         xml_data (str): The XML response from arXiv API.
 
     Returns:
-        list[Paper]: A list of Paper objects, each containing 'title' and 'abstract'.
+        list[Paper]: A list of Paper objects containing available metadata.
     """
     papers = []
     try:
         root = ET.fromstring(xml_data)
-        for entry in root.findall("{http://www.w3.org/2005/Atom}entry"):
+        for entry in root.findall(f"{ATOM_NAMESPACE}entry"):
             if entry is None:
                 continue
             papers.append(extract_metadata(entry))

--- a/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
@@ -5,7 +5,7 @@ from typing import Optional
 from arxiv_recommender.arxiv_paper_fetcher.utils import remove_control_characters
 from arxiv_recommender.schemas import Paper
 
-ATOM_NAMESPACE = "{http://www.w3.org/2005/Atom}"
+ATOM_NAMESPACES = {"atom": "http://www.w3.org/2005/Atom"}
 
 
 class ArxivParseError(ValueError):
@@ -14,7 +14,7 @@ class ArxivParseError(ValueError):
 
 def _get_text(entry: ET.Element, field: str) -> str:
     """Return normalized text for an Atom child element."""
-    element = entry.find(f"{ATOM_NAMESPACE}{field}")
+    element = entry.find(f"atom:{field}", ATOM_NAMESPACES)
     return (
         remove_control_characters(element.text.strip())
         if element is not None and element.text
@@ -51,12 +51,12 @@ def extract_metadata(entry: ET.Element) -> Paper:
     abstract = _get_text(entry, "summary")
     authors = [
         name
-        for author in entry.findall(f"{ATOM_NAMESPACE}author")
+        for author in entry.findall("atom:author", ATOM_NAMESPACES)
         if (name := _get_text(author, "name"))
     ]
     categories = [
         term
-        for category in entry.findall(f"{ATOM_NAMESPACE}category")
+        for category in entry.findall("atom:category", ATOM_NAMESPACES)
         if (term := category.get("term"))
     ]
 
@@ -87,7 +87,7 @@ def parse_paper_info(xml_data: str) -> Optional[Paper]:
     """
     try:
         root = ET.fromstring(xml_data)
-        entry = root.find(f"{ATOM_NAMESPACE}entry")
+        entry = root.find("atom:entry", ATOM_NAMESPACES)
         if entry is None:
             return None
         return extract_metadata(entry)
@@ -108,7 +108,7 @@ def parse_papers(xml_data: str) -> list[Paper]:
     papers = []
     try:
         root = ET.fromstring(xml_data)
-        for entry in root.findall(f"{ATOM_NAMESPACE}entry"):
+        for entry in root.findall("atom:entry", ATOM_NAMESPACES):
             if entry is None:
                 continue
             papers.append(extract_metadata(entry))

--- a/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/parser.py
@@ -30,7 +30,10 @@ def _extract_arxiv_id(url: str) -> str:
 def _get_datetime(entry: ET.Element, field: str) -> datetime | None:
     """Return an Atom timestamp as a datetime when present."""
     value = _get_text(entry, field)
-    return datetime.fromisoformat(value) if value else None
+    if not value:
+        return None
+    normalized_value = value.removesuffix("Z") + "+00:00" if value.endswith("Z") else value
+    return datetime.fromisoformat(normalized_value)
 
 
 def extract_metadata(entry: ET.Element) -> Paper:

--- a/src/arxiv_recommender/cli.py
+++ b/src/arxiv_recommender/cli.py
@@ -86,8 +86,15 @@ def main() -> None:
     result = pipeline.run(date_of_pulling_papers=args.date_of_pulling_papers)
 
     logger.info("Top recommended papers:")
-    for i, paper in enumerate(result.recommendations, 1):
-        logger.info("%d. %s (%s)", i, paper["title"], paper["abstract"])
+    for i, recommendation in enumerate(result.recommendations, 1):
+        paper = recommendation.paper
+        logger.info(
+            "%d. %s (%s) [%s]",
+            i,
+            paper.title,
+            paper.abstract,
+            paper.url or "URL unavailable",
+        )
 
     if args.stats or log_level == "DEBUG":
         logger.info("Metrics summary: %s", result.metrics_summary)

--- a/src/arxiv_recommender/favorite_papers/loader.py
+++ b/src/arxiv_recommender/favorite_papers/loader.py
@@ -5,6 +5,13 @@ from arxiv_recommender.schemas import Paper
 from arxiv_recommender.utils.json_handler import load_json, save_json
 
 
+def _parse_favorite_paper(data: object) -> Paper:
+    """Validate a single favorite-paper JSON object."""
+    if not isinstance(data, dict):
+        raise ValueError("Each favorite paper must be a JSON object.")
+    return Paper.model_validate(data)
+
+
 def load_favorite_papers(
     favorite_papers_path: str,
 ) -> list[Paper]:
@@ -27,9 +34,11 @@ def load_favorite_papers(
         save_json(favorite_papers_path, [])
         return []
 
-    favorite_papers_data: list[dict[str, object]] = load_json(favorite_papers_path)
+    favorite_papers_data = load_json(favorite_papers_path)
+    if not isinstance(favorite_papers_data, list):
+        raise ValueError("Favorite papers file must contain a JSON array.")
 
-    favorite_papers = [Paper.model_validate(paper) for paper in favorite_papers_data]
+    favorite_papers = [_parse_favorite_paper(paper) for paper in favorite_papers_data]
 
     logging.info(f"Successfully loaded {len(favorite_papers)} favorite papers.")
     return favorite_papers

--- a/src/arxiv_recommender/favorite_papers/loader.py
+++ b/src/arxiv_recommender/favorite_papers/loader.py
@@ -27,9 +27,9 @@ def load_favorite_papers(
         save_json(favorite_papers_path, [])
         return []
 
-    favorite_papers_data: list[dict[str, str]] = load_json(favorite_papers_path)
+    favorite_papers_data: list[dict[str, object]] = load_json(favorite_papers_path)
 
-    favorite_papers = [Paper(**paper) for paper in favorite_papers_data]
+    favorite_papers = [Paper.model_validate(paper) for paper in favorite_papers_data]
 
     logging.info(f"Successfully loaded {len(favorite_papers)} favorite papers.")
     return favorite_papers

--- a/src/arxiv_recommender/recommendation/__init__.py
+++ b/src/arxiv_recommender/recommendation/__init__.py
@@ -1,8 +1,9 @@
 from arxiv_recommender.recommendation.pipeline import RecommendationPipeline
 from arxiv_recommender.recommendation.recommendation import Recommender
-from arxiv_recommender.recommendation.types import RecommendationRunResult
+from arxiv_recommender.recommendation.types import RecommendationItem, RecommendationRunResult
 
 __all__ = [
+    "RecommendationItem",
     "RecommendationPipeline",
     "RecommendationRunResult",
     "Recommender",

--- a/src/arxiv_recommender/recommendation/recommendation.py
+++ b/src/arxiv_recommender/recommendation/recommendation.py
@@ -1,9 +1,9 @@
 from time import perf_counter
 
 import numpy as np
-from typing import Any
 from sklearn.metrics.pairwise import cosine_similarity
 
+from arxiv_recommender.recommendation.types import RecommendationItem
 from arxiv_recommender.schemas import Paper
 from arxiv_recommender.text_vectorization import TextEmbedder
 from arxiv_recommender.utils.metrics import MetricsCollector
@@ -63,7 +63,7 @@ class Recommender:
 
     def recommend_by_papers(
         self, candidate_papers: list[Paper], top_k: int | None = None
-    ) -> list[dict[str, Any]]:
+    ) -> list[RecommendationItem]:
         """Recommends papers based on the highest similarity to favorite papers.
 
         Args:
@@ -99,9 +99,8 @@ class Recommender:
         )
 
         # Extract ranked papers with similarity scores
-        ranked_papers: list[dict[str, Any]] = [
-            {"title": paper.title, "abstract": paper.abstract, "score": float(score)}
-            for paper, score in sorted_papers
+        ranked_papers = [
+            RecommendationItem(paper=paper, score=float(score)) for paper, score in sorted_papers
         ]
 
         return ranked_papers[:top_k] if top_k else ranked_papers

--- a/src/arxiv_recommender/recommendation/types.py
+++ b/src/arxiv_recommender/recommendation/types.py
@@ -2,11 +2,22 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from arxiv_recommender.schemas import Paper
+
+
+class RecommendationItem(BaseModel):
+    """A ranked paper recommendation."""
+
+    paper: Paper
+    score: float
+
+    model_config = {"frozen": True}
+
 
 class RecommendationRunResult(BaseModel):
     """Structured output for a recommendation pipeline execution."""
 
-    recommendations: list[dict[str, Any]] = Field(default_factory=list)
+    recommendations: list[RecommendationItem] = Field(default_factory=list)
     metrics_summary: dict[str, Any] = Field(default_factory=dict)
     favorite_papers_count: int
     candidate_papers_count: int

--- a/src/arxiv_recommender/schemas/paper.py
+++ b/src/arxiv_recommender/schemas/paper.py
@@ -1,8 +1,16 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 
 class Paper(BaseModel):
+    arxiv_id: str | None = Field(default=None, description="arXiv paper identifier")
+    url: str | None = Field(default=None, description="Canonical paper URL")
     title: str = Field(description="Title of the paper")
     abstract: str = Field(description="Abstract of the paper")
+    authors: list[str] = Field(default_factory=list, description="Paper authors")
+    categories: list[str] = Field(default_factory=list, description="arXiv categories")
+    published: datetime | None = Field(default=None, description="Publication timestamp")
+    updated: datetime | None = Field(default=None, description="Last update timestamp")
 
     model_config = {"frozen": True}

--- a/tests/arxiv_paper_fetcher/test_parser.py
+++ b/tests/arxiv_paper_fetcher/test_parser.py
@@ -1,5 +1,7 @@
 import unittest
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
 from arxiv_recommender.arxiv_paper_fetcher.parser import (
     ArxivParseError,
     extract_metadata,
@@ -63,6 +65,14 @@ class TestParser(unittest.TestCase):
         assert paper is not None
         self.assertEqual(paper.title, "Sample Paper")
         self.assertEqual(paper.abstract, "Sample Abstract")
+
+    def test_parse_paper_info_parses_utc_z_timestamps(self) -> None:
+        """Test UTC timestamps use a Python 3.10-compatible representation."""
+        paper = parse_paper_info(self.sample_entry)
+
+        assert paper is not None
+        self.assertEqual(paper.published, datetime(2026, 5, 1, 12, tzinfo=timezone.utc))
+        self.assertEqual(paper.updated, datetime(2026, 5, 2, 12, tzinfo=timezone.utc))
 
     def test_parse_paper_info_empty_feed_returns_none(self) -> None:
         """Test parsing a valid feed with no entry returns None."""

--- a/tests/arxiv_paper_fetcher/test_parser.py
+++ b/tests/arxiv_paper_fetcher/test_parser.py
@@ -14,8 +14,15 @@ class TestParser(unittest.TestCase):
         self.sample_entry = """
         <feed xmlns="http://www.w3.org/2005/Atom">
             <entry>
+                <id>http://arxiv.org/abs/1234.56789</id>
                 <title>Sample Paper</title>
                 <summary>Sample Abstract</summary>
+                <author><name>Ada Lovelace</name></author>
+                <author><name>Grace Hopper</name></author>
+                <category term="cs.AI"/>
+                <category term="cs.LG"/>
+                <published>2026-05-01T12:00:00Z</published>
+                <updated>2026-05-02T12:00:00Z</updated>
             </entry>
         </feed>
         """
@@ -39,8 +46,16 @@ class TestParser(unittest.TestCase):
         entry = root.find("{http://www.w3.org/2005/Atom}entry")
         assert entry is not None
         metadata = extract_metadata(entry)
+        self.assertEqual(metadata.arxiv_id, "1234.56789")
+        self.assertEqual(metadata.url, "http://arxiv.org/abs/1234.56789")
         self.assertEqual(metadata.title, "Sample Paper")
         self.assertEqual(metadata.abstract, "Sample Abstract")
+        self.assertEqual(metadata.authors, ["Ada Lovelace", "Grace Hopper"])
+        self.assertEqual(metadata.categories, ["cs.AI", "cs.LG"])
+        assert metadata.published is not None
+        assert metadata.updated is not None
+        self.assertEqual(metadata.published.isoformat(), "2026-05-01T12:00:00+00:00")
+        self.assertEqual(metadata.updated.isoformat(), "2026-05-02T12:00:00+00:00")
 
     def test_parse_paper_info(self) -> None:
         """Test extracting title and abstract from a single entry"""

--- a/tests/favorite_papers/test_loader.py
+++ b/tests/favorite_papers/test_loader.py
@@ -13,7 +13,7 @@ class TestPaperLoader(unittest.TestCase):
         """Setup sample data before each test."""
         self.sample_data = [{"title": "Sample Paper", "abstract": "Test abstract."}]
         save_json("test_favorite_papers.json", self.sample_data)
-        self.expected_papers = [Paper(**p) for p in self.sample_data]
+        self.expected_papers = [Paper.model_validate(p) for p in self.sample_data]
 
     def tearDown(self) -> None:
         """Cleanup test JSON file after tests."""
@@ -33,3 +33,21 @@ class TestPaperLoader(unittest.TestCase):
             result = load_favorite_papers("non_existent.json")
             self.assertEqual(result, [])
             self.assertIn("Creating empty favorite papers file", log.output[1])
+
+    def test_load_favorite_papers_rejects_non_list_json(self) -> None:
+        """Test favorite papers must be stored as a JSON array."""
+        save_json("test_favorite_papers.json", {"title": "Not a list"})
+
+        with self.assertRaises(ValueError) as context:
+            load_favorite_papers("test_favorite_papers.json")
+
+        self.assertEqual(str(context.exception), "Favorite papers file must contain a JSON array.")
+
+    def test_load_favorite_papers_rejects_non_object_items(self) -> None:
+        """Test each favorite paper entry must be a JSON object."""
+        save_json("test_favorite_papers.json", ["not an object"])
+
+        with self.assertRaises(ValueError) as context:
+            load_favorite_papers("test_favorite_papers.json")
+
+        self.assertEqual(str(context.exception), "Each favorite paper must be a JSON object.")

--- a/tests/recommendation/test_pipeline.py
+++ b/tests/recommendation/test_pipeline.py
@@ -28,7 +28,12 @@ class TestRecommendationPipeline(unittest.TestCase):
             Paper(title="Favorite 2", abstract="About neural networks."),
         ]
         self.daily_papers = [
-            Paper(title="Candidate 1", abstract="About transformers."),
+            Paper(
+                arxiv_id="1234.56789",
+                url="http://arxiv.org/abs/1234.56789",
+                title="Candidate 1",
+                abstract="About transformers.",
+            ),
             Paper(title="Candidate 2", abstract="About optimization."),
             Paper(title="Candidate 3", abstract="About statistics."),
         ]
@@ -76,6 +81,16 @@ class TestRecommendationPipeline(unittest.TestCase):
         result = pipeline.run()
 
         self.assertEqual(len(result.recommendations), self.config.top_k)
+
+    def test_run_preserves_recommendation_metadata(self) -> None:
+        pipeline = self._create_pipeline()
+
+        result = pipeline.run()
+
+        metadata_recommendation = next(
+            item for item in result.recommendations if item.paper.arxiv_id == "1234.56789"
+        )
+        self.assertEqual(metadata_recommendation.paper, self.daily_papers[0])
 
     def test_run_returns_empty_recommendations_for_empty_daily_papers(self) -> None:
         self.mock_fetcher.get_daily_papers.return_value = []

--- a/tests/recommendation/test_pipeline.py
+++ b/tests/recommendation/test_pipeline.py
@@ -83,6 +83,7 @@ class TestRecommendationPipeline(unittest.TestCase):
         self.assertEqual(len(result.recommendations), self.config.top_k)
 
     def test_run_preserves_recommendation_metadata(self) -> None:
+        """RecommendationPipeline should not drop metadata while orchestrating ranking."""
         pipeline = self._create_pipeline()
 
         result = pipeline.run()

--- a/tests/recommendation/test_recommender.py
+++ b/tests/recommendation/test_recommender.py
@@ -22,7 +22,14 @@ class TestRecommender(unittest.TestCase):
         ]
 
         self.candidate_papers = [
-            Paper(title="Deep Learning", abstract="Neural networks and optimization."),
+            Paper(
+                arxiv_id="1234.56789",
+                url="http://arxiv.org/abs/1234.56789",
+                title="Deep Learning",
+                abstract="Neural networks and optimization.",
+                authors=["Ada Lovelace"],
+                categories=["cs.LG"],
+            ),
             Paper(title="Machine Learning", abstract="ML techniques and applications."),
             Paper(title="Quantum AI", abstract="AI techniques for quantum systems."),
         ]
@@ -47,8 +54,17 @@ class TestRecommender(unittest.TestCase):
         self.assertTrue(len(recommendations) > 0)
         self.assertEqual(len(recommendations), len(self.candidate_papers))
         self.assertEqual(
-            sorted(recommendations, key=lambda x: x["score"], reverse=True), recommendations
+            sorted(recommendations, key=lambda item: item.score, reverse=True), recommendations
         )
+
+    def test_recommend_by_papers_preserves_metadata(self) -> None:
+        """Test ranked recommendations retain the complete paper model."""
+        recommendations = self.recommender.recommend_by_papers(self.candidate_papers)
+
+        metadata_recommendation = next(
+            item for item in recommendations if item.paper.arxiv_id == "1234.56789"
+        )
+        self.assertEqual(metadata_recommendation.paper, self.candidate_papers[0])
 
     def test_recommend_by_papers_with_top_k(self) -> None:
         """Test if top_k parameter limits the results correctly."""

--- a/tests/schemas/test_paper.py
+++ b/tests/schemas/test_paper.py
@@ -1,11 +1,14 @@
+from datetime import datetime
+
 import pytest
+
 from arxiv_recommender.schemas.paper import Paper
 
 
 class TestPaper:
     """Tests for Paper schema."""
 
-    def test_create_paper_with_valid_data(self):
+    def test_create_paper_with_valid_data(self) -> None:
         """Test creating a Paper with valid data."""
         paper = Paper(
             title="Sample Paper Title", abstract="This is a sample abstract for testing purposes."
@@ -13,31 +16,58 @@ class TestPaper:
         assert paper.title == "Sample Paper Title"
         assert paper.abstract == "This is a sample abstract for testing purposes."
 
-    def test_paper_is_frozen(self):
+    def test_paper_is_frozen(self) -> None:
         """Test that Paper is immutable after creation."""
         paper = Paper(title="Test", abstract="Test abstract")
         with pytest.raises(Exception):
             paper.title = "New Title"
 
-    def test_paper_serialization(self):
+    def test_paper_serialization(self) -> None:
         """Test Paper can be serialized to dict."""
         paper = Paper(title="Test", abstract="Test abstract")
         data = paper.model_dump()
-        assert data == {"title": "Test", "abstract": "Test abstract"}
+        assert data == {
+            "arxiv_id": None,
+            "url": None,
+            "title": "Test",
+            "abstract": "Test abstract",
+            "authors": [],
+            "categories": [],
+            "published": None,
+            "updated": None,
+        }
 
-    def test_paper_json_serialization(self):
+    def test_paper_json_serialization(self) -> None:
         """Test Paper can be serialized to JSON."""
         paper = Paper(title="Test", abstract="Test abstract")
         json_str = paper.model_dump_json()
         assert '"title":"Test"' in json_str
 
-    def test_paper_from_dict(self):
+    def test_paper_from_dict(self) -> None:
         """Test creating Paper from dictionary."""
         data = {"title": "From Dict", "abstract": "From dict abstract"}
-        paper = Paper(**data)
+        paper = Paper.model_validate(data)
         assert paper.title == "From Dict"
 
-    def test_paper_required_fields(self):
+    def test_paper_required_fields(self) -> None:
         """Test that title and abstract are required."""
         with pytest.raises(Exception):
-            Paper()
+            Paper()  # type: ignore[call-arg]
+
+    def test_create_paper_with_arxiv_metadata(self) -> None:
+        """Test creating a paper with traceable arXiv metadata."""
+        paper = Paper(
+            arxiv_id="1234.56789",
+            url="http://arxiv.org/abs/1234.56789",
+            title="Metadata Paper",
+            abstract="Metadata abstract",
+            authors=["Ada Lovelace", "Grace Hopper"],
+            categories=["cs.AI", "cs.LG"],
+            published=datetime.fromisoformat("2026-05-01T12:00:00+00:00"),
+            updated=datetime.fromisoformat("2026-05-02T12:00:00+00:00"),
+        )
+
+        assert paper.arxiv_id == "1234.56789"
+        assert paper.authors == ["Ada Lovelace", "Grace Hopper"]
+        assert paper.categories == ["cs.AI", "cs.LG"]
+        assert paper.published == datetime.fromisoformat("2026-05-01T12:00:00+00:00")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from arxiv_recommender import cli
-from arxiv_recommender.recommendation.types import RecommendationRunResult
-from arxiv_recommender.schemas import AppConfig, VectorizerConfig
+from arxiv_recommender.recommendation.types import RecommendationItem, RecommendationRunResult
+from arxiv_recommender.schemas import AppConfig, Paper, VectorizerConfig
 
 
 class TestCli(unittest.TestCase):
@@ -22,8 +22,19 @@ class TestCli(unittest.TestCase):
         )
         self.result = RecommendationRunResult(
             recommendations=[
-                {"title": "Paper 1", "abstract": "Abstract 1", "score": 0.9},
-                {"title": "Paper 2", "abstract": "Abstract 2", "score": 0.8},
+                RecommendationItem(
+                    paper=Paper(
+                        arxiv_id="1234.56789",
+                        url="http://arxiv.org/abs/1234.56789",
+                        title="Paper 1",
+                        abstract="Abstract 1",
+                    ),
+                    score=0.9,
+                ),
+                RecommendationItem(
+                    paper=Paper(title="Paper 2", abstract="Abstract 2"),
+                    score=0.8,
+                ),
             ],
             metrics_summary={"cache": {"hits": 1}},
             favorite_papers_count=2,
@@ -116,6 +127,13 @@ class TestCli(unittest.TestCase):
 
         mock_setup_logging.assert_called_once_with(level="INFO", json_format=True)
         mock_logger.info.assert_any_call("Metrics summary: %s", self.result.metrics_summary)
+        mock_logger.info.assert_any_call(
+            "%d. %s (%s) [%s]",
+            1,
+            "Paper 1",
+            "Abstract 1",
+            "http://arxiv.org/abs/1234.56789",
+        )
         mock_fetcher_class.assert_called_once()
         mock_load_vectorization_model.assert_called_once()
         mock_metrics_class.assert_called_once()


### PR DESCRIPTION
## Summary
- expand `Paper` with optional arXiv identity, URL, authors, categories, and typed timestamps while preserving compatibility with existing favorite-paper files
- parse available Atom metadata and preserve complete paper models through typed recommendation results
- include recommendation URLs in CLI output and validate favorite-paper JSON through Pydantic
- add regression coverage for metadata parsing, serialization, ranking, pipeline output, and CLI formatting

## Verification
```bash
uv run ruff check . && uv run ruff format --check . && uv run python -m mypy src && uv run python -m pytest
```

Closes #28