### PR TITLE
fix: validate arxiv query parameters

### DIFF
--- a/src/arxiv_recommender/arxiv_paper_fetcher/fetcher.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/fetcher.py
@@ -2,12 +2,11 @@
 
 import logging
 import requests
-from typing import Optional
 
 from arxiv_recommender.schemas import Paper
 from arxiv_recommender.utils.retry import retry_with_backoff
 from .parser import parse_paper_info, parse_papers
-from .utils import format_arxiv_query
+from .utils import build_arxiv_query_params
 
 
 class ArxivFetcher:
@@ -20,14 +19,14 @@ class ArxivFetcher:
             max_results: Maximum results per API call (default: 2000).
             timeout: Timeout for API requests in seconds (default: 10).
         """
-        self.base_url = "http://export.arxiv.org/api/query?"
+        self.base_url = "http://export.arxiv.org/api/query"
         self.namespace = {"arxiv": "http://www.w3.org/2005/Atom"}
         self.max_results = max_results
         self.timeout = timeout
         self._logger = logging.getLogger(__name__)
 
     @retry_with_backoff(max_retries=3, initial_delay=1.0, backoff_factor=2.0)
-    def get_paper_by_id(self, paper_id: str) -> Optional[Paper]:
+    def get_paper_by_id(self, paper_id: str) -> Paper | None:
         """Fetches a single paper's title and abstract using its arXiv ID.
 
         Args:
@@ -39,16 +38,13 @@ class ArxivFetcher:
         Raises:
             requests.RequestException: If the API request fails.
         """
-        url = f"{self.base_url}id_list={paper_id}"
-        response = requests.get(url, timeout=self.timeout)
+        response = requests.get(self.base_url, params={"id_list": paper_id}, timeout=self.timeout)
         response.raise_for_status()
 
         return parse_paper_info(response.text)
 
     @retry_with_backoff(max_retries=3, initial_delay=1.0, backoff_factor=2.0)
-    def get_daily_papers(
-        self, date: Optional[str] = None, category: Optional[str] = None
-    ) -> list[Paper]:
+    def get_daily_papers(self, date: str | None = None, category: str | None = None) -> list[Paper]:
         """Fetches papers submitted to arXiv in the last 24 hours or on a specific date.
 
         Args:
@@ -62,11 +58,10 @@ class ArxivFetcher:
         Raises:
             requests.RequestException: If the API request fails.
         """
-        query = format_arxiv_query(date, category, max_results=self.max_results)
-        self._logger.info("Fetching daily papers with query: %s", query)
-        url = f"{self.base_url}{query}&max_results={self.max_results}"
+        params = build_arxiv_query_params(date, category, max_results=self.max_results)
+        self._logger.info("Fetching daily papers with params: %s", params)
 
-        response = requests.get(url, timeout=self.timeout)
+        response = requests.get(self.base_url, params=params, timeout=self.timeout)
         response.raise_for_status()
 
         papers = parse_papers(response.text)

--- a/src/arxiv_recommender/arxiv_paper_fetcher/utils.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/utils.py
@@ -18,11 +18,11 @@ def validate_arxiv_date(date: str) -> str:
         ValueError: If the date is not a real date in YYYYMMDD format.
     """
     if not ARXIV_DATE_PATTERN.fullmatch(date):
-        raise ValueError("Date must be in YYYYMMDD format.")
+        raise ValueError(f"Date must be in YYYYMMDD format; got {date!r}.")
     try:
         datetime.strptime(date, "%Y%m%d")
     except ValueError:
-        raise ValueError("Date must be in YYYYMMDD format.") from None
+        raise ValueError(f"Date must be in YYYYMMDD format; got {date!r}.") from None
     return date
 
 

--- a/src/arxiv_recommender/arxiv_paper_fetcher/utils.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/utils.py
@@ -1,12 +1,15 @@
+import re
 from datetime import datetime, timedelta
-from typing import Optional
+
+ARXIV_DATE_PATTERN = re.compile(r"^\d{8}$")
+ARXIV_CATEGORY_PATTERN = re.compile(r"^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)?$")
 
 
-def format_arxiv_query(
-    date: Optional[str] = None, category: Optional[str] = None, max_results: int = 50
-) -> str:
+def build_arxiv_query_params(
+    date: str | None = None, category: str | None = None, max_results: int = 50
+) -> dict[str, str | int]:
     """
-    Formats the search query for arXiv API to fetch papers from the last 24 hours.
+    Builds search parameters for the arXiv API.
 
     Args:
         date (Optional[str]): The date for which to fetch papers in YYYYMMDD format.
@@ -16,26 +19,29 @@ def format_arxiv_query(
         max_results (int): The maximum number of results to fetch (default is 50).
 
     Returns:
-        str: The formatted query string.
+        dict[str, str | int]: Query parameters for requests.get(..., params=...).
     """
-    if date:
-        # If a specific date is provided, use it to format the query
+    if date is not None:
+        if not ARXIV_DATE_PATTERN.fullmatch(date):
+            raise ValueError("Date must be in YYYYMMDD format.")
         try:
             date_obj = datetime.strptime(date, "%Y%m%d")
         except ValueError:
-            raise ValueError("Date must be in YYYYMMDD format.")
+            raise ValueError("Date must be in YYYYMMDD format.") from None
         date_str = date_obj.strftime("%Y%m%d")
     else:
         yesterday = datetime.now().astimezone() - timedelta(days=1)
         date_str = yesterday.strftime("%Y%m%d")
-    query = (
-        f"search_query=submittedDate:[{date_str}0000+TO+{date_str}2359]&max_results={max_results}"
-    )
 
-    if category:
-        query = f"search_query=cat:{category}+AND+submittedDate:[{date_str}0000+TO+{date_str}2359]&max_results={max_results}"
+    submitted_date_query = f"submittedDate:[{date_str}0000 TO {date_str}2359]"
+    if category is not None:
+        if not ARXIV_CATEGORY_PATTERN.fullmatch(category):
+            raise ValueError("Category must be an arXiv category such as 'cs.LG'.")
+        search_query = f"cat:{category} AND {submitted_date_query}"
+    else:
+        search_query = submitted_date_query
 
-    return query
+    return {"search_query": search_query, "max_results": max_results}
 
 
 def remove_control_characters(text: str) -> str:

--- a/src/arxiv_recommender/arxiv_paper_fetcher/utils.py
+++ b/src/arxiv_recommender/arxiv_paper_fetcher/utils.py
@@ -5,6 +5,44 @@ ARXIV_DATE_PATTERN = re.compile(r"^\d{8}$")
 ARXIV_CATEGORY_PATTERN = re.compile(r"^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)?$")
 
 
+def validate_arxiv_date(date: str) -> str:
+    """Validate an arXiv API date string.
+
+    Args:
+        date: Date in YYYYMMDD format.
+
+    Returns:
+        The validated date.
+
+    Raises:
+        ValueError: If the date is not a real date in YYYYMMDD format.
+    """
+    if not ARXIV_DATE_PATTERN.fullmatch(date):
+        raise ValueError("Date must be in YYYYMMDD format.")
+    try:
+        datetime.strptime(date, "%Y%m%d")
+    except ValueError:
+        raise ValueError("Date must be in YYYYMMDD format.") from None
+    return date
+
+
+def validate_arxiv_category(category: str) -> str:
+    """Validate an arXiv category string.
+
+    Args:
+        category: arXiv category such as 'cs.LG'.
+
+    Returns:
+        The validated category.
+
+    Raises:
+        ValueError: If the category is not in an arXiv category shape.
+    """
+    if not ARXIV_CATEGORY_PATTERN.fullmatch(category):
+        raise ValueError("Category must be an arXiv category such as 'cs.LG'.")
+    return category
+
+
 def build_arxiv_query_params(
     date: str | None = None, category: str | None = None, max_results: int = 50
 ) -> dict[str, str | int]:
@@ -22,21 +60,14 @@ def build_arxiv_query_params(
         dict[str, str | int]: Query parameters for requests.get(..., params=...).
     """
     if date is not None:
-        if not ARXIV_DATE_PATTERN.fullmatch(date):
-            raise ValueError("Date must be in YYYYMMDD format.")
-        try:
-            date_obj = datetime.strptime(date, "%Y%m%d")
-        except ValueError:
-            raise ValueError("Date must be in YYYYMMDD format.") from None
-        date_str = date_obj.strftime("%Y%m%d")
+        date_str = validate_arxiv_date(date)
     else:
         yesterday = datetime.now().astimezone() - timedelta(days=1)
         date_str = yesterday.strftime("%Y%m%d")
 
     submitted_date_query = f"submittedDate:[{date_str}0000 TO {date_str}2359]"
     if category is not None:
-        if not ARXIV_CATEGORY_PATTERN.fullmatch(category):
-            raise ValueError("Category must be an arXiv category such as 'cs.LG'.")
+        category = validate_arxiv_category(category)
         search_query = f"cat:{category} AND {submitted_date_query}"
     else:
         search_query = submitted_date_query

--- a/src/arxiv_recommender/cli.py
+++ b/src/arxiv_recommender/cli.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from arxiv_recommender.arxiv_paper_fetcher.fetcher import ArxivFetcher
+from arxiv_recommender.arxiv_paper_fetcher.utils import validate_arxiv_date
 from arxiv_recommender.favorite_papers import FileFavoritePapersProvider
 from arxiv_recommender.recommendation import RecommendationPipeline
 from arxiv_recommender.schemas import AppConfig
@@ -10,6 +11,14 @@ from arxiv_recommender.utils import MetricsCollector, setup_logging
 from arxiv_recommender.utils.json_handler import load_json
 from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
 from arxiv_recommender.utils.model_loader import load_vectorization_model
+
+
+def parse_arxiv_date(value: str) -> str:
+    """Parse and validate a CLI date argument."""
+    try:
+        return validate_arxiv_date(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from None
 
 
 def load_config(config_path: str) -> AppConfig:
@@ -40,9 +49,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--date_of_pulling_papers",
-        type=str,
+        type=parse_arxiv_date,
         default=None,
-        help="Date of pulling papers in YYYYMMDD format. If not provided, defaults to today.",
+        help="Date of pulling papers in YYYYMMDD format. If not provided, defaults to yesterday.",
     )
     parser.add_argument(
         "--log-level",

--- a/src/arxiv_recommender/cli.py
+++ b/src/arxiv_recommender/cli.py
@@ -13,8 +13,8 @@ from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
 from arxiv_recommender.utils.model_loader import load_vectorization_model
 
 
-def parse_arxiv_date(value: str) -> str:
-    """Parse and validate a CLI date argument."""
+def _parse_arxiv_date(value: str) -> str:
+    """Adapt arXiv date validation for argparse error handling."""
     try:
         return validate_arxiv_date(value)
     except ValueError as exc:
@@ -49,7 +49,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--date_of_pulling_papers",
-        type=parse_arxiv_date,
+        type=_parse_arxiv_date,
         default=None,
         help="Date of pulling papers in YYYYMMDD format. If not provided, defaults to yesterday.",
     )

--- a/src/arxiv_recommender/cli.py
+++ b/src/arxiv_recommender/cli.py
@@ -1,14 +1,12 @@
 import argparse
 import logging
-import os
 
 from arxiv_recommender.arxiv_paper_fetcher.fetcher import ArxivFetcher
 from arxiv_recommender.arxiv_paper_fetcher.utils import validate_arxiv_date
 from arxiv_recommender.favorite_papers import FileFavoritePapersProvider
 from arxiv_recommender.recommendation import RecommendationPipeline
-from arxiv_recommender.schemas import AppConfig
 from arxiv_recommender.utils import MetricsCollector, setup_logging
-from arxiv_recommender.utils.json_handler import load_json
+from arxiv_recommender.utils.config_loader import load_config
 from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
 from arxiv_recommender.utils.model_loader import load_vectorization_model
 
@@ -19,24 +17,6 @@ def _parse_arxiv_date(value: str) -> str:
         return validate_arxiv_date(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from None
-
-
-def load_config(config_path: str) -> AppConfig:
-    """Loads the configuration file.
-
-    Args:
-        config_path: Path to the configuration JSON file.
-
-    Returns:
-        Parsed configuration object.
-
-    Raises:
-        FileNotFoundError: If the configuration file is missing.
-    """
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(f"Configuration file not found: {config_path}")
-    config_data = load_json(config_path)
-    return AppConfig.model_validate(config_data)
 
 
 def main() -> None:

--- a/src/arxiv_recommender/utils/config_loader.py
+++ b/src/arxiv_recommender/utils/config_loader.py
@@ -1,0 +1,22 @@
+import os
+
+from arxiv_recommender.schemas import AppConfig
+from arxiv_recommender.utils.json_handler import load_json
+
+
+def load_config(config_path: str) -> AppConfig:
+    """Load and validate an application configuration file.
+
+    Args:
+        config_path: Path to the configuration JSON file.
+
+    Returns:
+        Parsed application configuration.
+
+    Raises:
+        FileNotFoundError: If the configuration file is missing.
+    """
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+    config_data = load_json(config_path)
+    return AppConfig.model_validate(config_data)

--- a/tests/arxiv_paper_fetcher/test_fetcher.py
+++ b/tests/arxiv_paper_fetcher/test_fetcher.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import requests
 from arxiv_recommender.arxiv_paper_fetcher.fetcher import ArxivFetcher
@@ -35,6 +35,11 @@ class TestArxivFetcher(unittest.TestCase):
         assert paper is not None
         self.assertEqual(paper.title, "Sample Paper")
         self.assertEqual(paper.abstract, "Sample Abstract")
+        mock_get.assert_called_once_with(
+            "http://export.arxiv.org/api/query",
+            params={"id_list": "1234.56789"},
+            timeout=self.fetcher.timeout,
+        )
         mock_response.raise_for_status.assert_called_once()
 
     @patch("arxiv_recommender.utils.retry.time.sleep", return_value=None)
@@ -104,6 +109,20 @@ class TestArxivFetcher(unittest.TestCase):
         self.assertEqual(len(papers), 2)
         self.assertEqual(papers[0].title, "Paper 1")
         self.assertEqual(papers[1].abstract, "Abstract 2")
+        mock_get.assert_called_once_with(
+            "http://export.arxiv.org/api/query",
+            params={
+                "search_query": ANY,
+                "max_results": self.fetcher.max_results,
+            },
+            timeout=self.fetcher.timeout,
+        )
+        request_params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(request_params["max_results"], self.fetcher.max_results)
+        self.assertEqual(
+            request_params["search_query"].split(" AND ")[0],
+            "cat:cs.AI",
+        )
         mock_response.raise_for_status.assert_called_once()
 
     @patch("requests.get")
@@ -117,6 +136,12 @@ class TestArxivFetcher(unittest.TestCase):
 
         papers = self.fetcher.get_daily_papers(category="cs.LG")
         self.assertEqual(len(papers), 0)
+        request_params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(request_params["max_results"], self.fetcher.max_results)
+        self.assertEqual(
+            request_params["search_query"].split(" AND ")[0],
+            "cat:cs.LG",
+        )
 
     @patch("requests.get")
     def test_get_daily_papers_malformed_xml_raises(self, mock_get: Mock) -> None:

--- a/tests/arxiv_paper_fetcher/test_fetcher.py
+++ b/tests/arxiv_paper_fetcher/test_fetcher.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 import requests
 from arxiv_recommender.arxiv_paper_fetcher.fetcher import ArxivFetcher
@@ -105,23 +105,17 @@ class TestArxivFetcher(unittest.TestCase):
         </feed>""")
         mock_get.return_value = mock_response
 
-        papers = self.fetcher.get_daily_papers(category="cs.AI")
+        papers = self.fetcher.get_daily_papers(date="20231001", category="cs.AI")
         self.assertEqual(len(papers), 2)
         self.assertEqual(papers[0].title, "Paper 1")
         self.assertEqual(papers[1].abstract, "Abstract 2")
         mock_get.assert_called_once_with(
             "http://export.arxiv.org/api/query",
             params={
-                "search_query": ANY,
+                "search_query": "cat:cs.AI AND submittedDate:[202310010000 TO 202310012359]",
                 "max_results": self.fetcher.max_results,
             },
             timeout=self.fetcher.timeout,
-        )
-        request_params = mock_get.call_args.kwargs["params"]
-        self.assertEqual(request_params["max_results"], self.fetcher.max_results)
-        self.assertEqual(
-            request_params["search_query"].split(" AND ")[0],
-            "cat:cs.AI",
         )
         mock_response.raise_for_status.assert_called_once()
 
@@ -134,13 +128,15 @@ class TestArxivFetcher(unittest.TestCase):
         </feed>""")
         mock_get.return_value = mock_response
 
-        papers = self.fetcher.get_daily_papers(category="cs.LG")
+        papers = self.fetcher.get_daily_papers(date="20231001", category="cs.LG")
         self.assertEqual(len(papers), 0)
-        request_params = mock_get.call_args.kwargs["params"]
-        self.assertEqual(request_params["max_results"], self.fetcher.max_results)
-        self.assertEqual(
-            request_params["search_query"].split(" AND ")[0],
-            "cat:cs.LG",
+        mock_get.assert_called_once_with(
+            "http://export.arxiv.org/api/query",
+            params={
+                "search_query": "cat:cs.LG AND submittedDate:[202310010000 TO 202310012359]",
+                "max_results": self.fetcher.max_results,
+            },
+            timeout=self.fetcher.timeout,
         )
 
     @patch("requests.get")

--- a/tests/arxiv_paper_fetcher/test_utils.py
+++ b/tests/arxiv_paper_fetcher/test_utils.py
@@ -2,6 +2,8 @@ import unittest
 from arxiv_recommender.arxiv_paper_fetcher.utils import (
     build_arxiv_query_params,
     remove_control_characters,
+    validate_arxiv_category,
+    validate_arxiv_date,
 )
 
 
@@ -43,6 +45,19 @@ class TestUtils(unittest.TestCase):
             with self.subTest(category=category):
                 with self.assertRaisesRegex(ValueError, "Category must be an arXiv category"):
                     build_arxiv_query_params(date="20231001", category=category)
+
+    def test_validate_arxiv_date_returns_valid_date(self) -> None:
+        """Test valid dates are returned unchanged."""
+        self.assertEqual(validate_arxiv_date("20231001"), "20231001")
+
+    def test_validate_arxiv_date_rejects_nonexistent_date(self) -> None:
+        """Test nonexistent calendar dates are rejected."""
+        with self.assertRaisesRegex(ValueError, "Date must be in YYYYMMDD format"):
+            validate_arxiv_date("20230230")
+
+    def test_validate_arxiv_category_returns_valid_category(self) -> None:
+        """Test valid categories are returned unchanged."""
+        self.assertEqual(validate_arxiv_category("cs.LG"), "cs.LG")
 
     def test_remove_control_characters(self) -> None:
         """Test removing control characters from a string"""

--- a/tests/arxiv_paper_fetcher/test_utils.py
+++ b/tests/arxiv_paper_fetcher/test_utils.py
@@ -40,11 +40,8 @@ class TestUtils(unittest.TestCase):
 
     def test_build_arxiv_query_params_rejects_invalid_category(self) -> None:
         """Test invalid categories are rejected."""
-        invalid_categories = ["", "cs AI", "cat:cs.AI", "cs.AI&max_results=100"]
-        for category in invalid_categories:
-            with self.subTest(category=category):
-                with self.assertRaisesRegex(ValueError, "Category must be an arXiv category"):
-                    build_arxiv_query_params(date="20231001", category=category)
+        with self.assertRaisesRegex(ValueError, "Category must be an arXiv category"):
+            build_arxiv_query_params(date="20231001", category="cs AI")
 
     def test_validate_arxiv_date_returns_valid_date(self) -> None:
         """Test valid dates are returned unchanged."""
@@ -58,6 +55,14 @@ class TestUtils(unittest.TestCase):
     def test_validate_arxiv_category_returns_valid_category(self) -> None:
         """Test valid categories are returned unchanged."""
         self.assertEqual(validate_arxiv_category("cs.LG"), "cs.LG")
+
+    def test_validate_arxiv_category_rejects_invalid_categories(self) -> None:
+        """Test invalid categories are rejected."""
+        invalid_categories = ["", "cs AI", "cat:cs.AI", "cs.AI&max_results=100"]
+        for category in invalid_categories:
+            with self.subTest(category=category):
+                with self.assertRaisesRegex(ValueError, "Category must be an arXiv category"):
+                    validate_arxiv_category(category)
 
     def test_remove_control_characters(self) -> None:
         """Test removing control characters from a string"""

--- a/tests/arxiv_paper_fetcher/test_utils.py
+++ b/tests/arxiv_paper_fetcher/test_utils.py
@@ -35,7 +35,10 @@ class TestUtils(unittest.TestCase):
         invalid_dates = ["", "2023-10-01"]
         for date in invalid_dates:
             with self.subTest(date=date):
-                with self.assertRaisesRegex(ValueError, "Date must be in YYYYMMDD format"):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    rf"Date must be in YYYYMMDD format; got {date!r}",
+                ):
                     build_arxiv_query_params(date=date, category="cs.AI")
 
     def test_build_arxiv_query_params_rejects_invalid_category(self) -> None:
@@ -49,7 +52,10 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_arxiv_date_rejects_nonexistent_date(self) -> None:
         """Test nonexistent calendar dates are rejected."""
-        with self.assertRaisesRegex(ValueError, "Date must be in YYYYMMDD format"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Date must be in YYYYMMDD format; got '20230230'",
+        ):
             validate_arxiv_date("20230230")
 
     def test_validate_arxiv_category_returns_valid_category(self) -> None:

--- a/tests/arxiv_paper_fetcher/test_utils.py
+++ b/tests/arxiv_paper_fetcher/test_utils.py
@@ -1,26 +1,50 @@
 import unittest
 from arxiv_recommender.arxiv_paper_fetcher.utils import (
-    format_arxiv_query,
+    build_arxiv_query_params,
     remove_control_characters,
 )
 
 
 class TestUtils(unittest.TestCase):
-    def test_format_arxiv_query(self):
-        """Test formatting arXiv API query with category and max_results"""
-        result = format_arxiv_query(category="cs.AI", max_results=100)
-        self.assertIn("search_query=cat:cs.AI", result)
-        self.assertIn("max_results=100", result)
-
-    def test_format_arxiv_query_with_date(self):
-        """Test formatting arXiv API query with date"""
-        result = format_arxiv_query(date="20231001", category="cs.AI", max_results=100)
-        self.assertIn(
-            "search_query=cat:cs.AI+AND+submittedDate:[202310010000+TO+202310012359]", result
+    def test_build_arxiv_query_params(self) -> None:
+        """Test building arXiv API query params with category and max_results."""
+        result = build_arxiv_query_params(date="20231001", category="cs.AI", max_results=100)
+        self.assertEqual(
+            result,
+            {
+                "search_query": "cat:cs.AI AND submittedDate:[202310010000 TO 202310012359]",
+                "max_results": 100,
+            },
         )
-        self.assertIn("max_results=100", result)
 
-    def test_remove_control_characters(self):
+    def test_build_arxiv_query_params_without_category(self) -> None:
+        """Test building arXiv API query params with date only."""
+        result = build_arxiv_query_params(date="20231001", max_results=100)
+        self.assertEqual(
+            result,
+            {
+                "search_query": "submittedDate:[202310010000 TO 202310012359]",
+                "max_results": 100,
+            },
+        )
+
+    def test_build_arxiv_query_params_rejects_invalid_date(self) -> None:
+        """Test invalid dates are rejected."""
+        invalid_dates = ["", "2023-10-01"]
+        for date in invalid_dates:
+            with self.subTest(date=date):
+                with self.assertRaisesRegex(ValueError, "Date must be in YYYYMMDD format"):
+                    build_arxiv_query_params(date=date, category="cs.AI")
+
+    def test_build_arxiv_query_params_rejects_invalid_category(self) -> None:
+        """Test invalid categories are rejected."""
+        invalid_categories = ["", "cs AI", "cat:cs.AI", "cs.AI&max_results=100"]
+        for category in invalid_categories:
+            with self.subTest(category=category):
+                with self.assertRaisesRegex(ValueError, "Category must be an arXiv category"):
+                    build_arxiv_query_params(date="20231001", category=category)
+
+    def test_remove_control_characters(self) -> None:
         """Test removing control characters from a string"""
         input_text = "Hello\nWorld\x00"
         cleaned_text = remove_control_characters(input_text)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,11 +177,11 @@ class TestCli(unittest.TestCase):
         mock_provider_class.assert_called_once()
 
     def test_parse_arxiv_date_accepts_valid_date(self) -> None:
-        self.assertEqual(cli.parse_arxiv_date("20260522"), "20260522")
+        self.assertEqual(cli._parse_arxiv_date("20260522"), "20260522")
 
     def test_parse_arxiv_date_rejects_invalid_date(self) -> None:
         with self.assertRaisesRegex(argparse.ArgumentTypeError, "Date must be in YYYYMMDD format"):
-            cli.parse_arxiv_date("2026-05-22")
+            cli._parse_arxiv_date("2026-05-22")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import argparse
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -174,6 +175,13 @@ class TestCli(unittest.TestCase):
         mock_load_vectorization_model.assert_called_once()
         mock_metrics_class.assert_called_once()
         mock_provider_class.assert_called_once()
+
+    def test_parse_arxiv_date_accepts_valid_date(self) -> None:
+        self.assertEqual(cli.parse_arxiv_date("20260522"), "20260522")
+
+    def test_parse_arxiv_date_rejects_invalid_date(self) -> None:
+        with self.assertRaisesRegex(argparse.ArgumentTypeError, "Date must be in YYYYMMDD format"):
+            cli.parse_arxiv_date("2026-05-22")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,7 +180,10 @@ class TestCli(unittest.TestCase):
         self.assertEqual(cli._parse_arxiv_date("20260522"), "20260522")
 
     def test_parse_arxiv_date_rejects_invalid_date(self) -> None:
-        with self.assertRaisesRegex(argparse.ArgumentTypeError, "Date must be in YYYYMMDD format"):
+        with self.assertRaisesRegex(
+            argparse.ArgumentTypeError,
+            "Date must be in YYYYMMDD format; got '2026-05-22'",
+        ):
             cli._parse_arxiv_date("2026-05-22")
 
 

--- a/tests/utils/test_config_loader.py
+++ b/tests/utils/test_config_loader.py
@@ -1,0 +1,59 @@
+import json
+import os
+import tempfile
+import unittest
+
+from pydantic import ValidationError
+
+from arxiv_recommender.schemas import AppConfig
+from arxiv_recommender.utils.config_loader import load_config
+
+
+class TestConfigLoader(unittest.TestCase):
+    def _write_config(self, config_data: dict[str, object]) -> str:
+        temp_file = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
+
+        def remove_temp_file() -> None:
+            if os.path.exists(temp_file.name):
+                os.remove(temp_file.name)
+
+        self.addCleanup(remove_temp_file)
+        with temp_file:
+            json.dump(config_data, temp_file)
+        return temp_file.name
+
+    def test_load_config_returns_validated_app_config(self) -> None:
+        config_path = self._write_config(
+            {
+                "favorite_papers_path": "favorite_papers.json",
+                "vectorizer": {
+                    "module_name": "huggingface_embed",
+                    "class_name": "HuggingFaceEmbedding",
+                    "model_name": "distilbert-base-uncased",
+                    "cache_size": 1000,
+                },
+                "top_k": 5,
+                "log_level": "debug",
+            }
+        )
+
+        config = load_config(config_path)
+
+        self.assertIsInstance(config, AppConfig)
+        self.assertEqual(config.favorite_papers_path, "favorite_papers.json")
+        self.assertEqual(config.top_k, 5)
+        self.assertEqual(config.log_level, "DEBUG")
+
+    def test_load_config_raises_for_missing_file(self) -> None:
+        with self.assertRaisesRegex(FileNotFoundError, "Configuration file not found"):
+            load_config("missing_config.json")
+
+    def test_load_config_raises_for_invalid_config_shape(self) -> None:
+        config_path = self._write_config({"favorite_papers_path": "favorite_papers.json"})
+
+        with self.assertRaises(ValidationError):
+            load_config(config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace manual arXiv URL query-string assembly with structured requests params
- validate daily paper date and category inputs before API calls
- assert fetcher request params in tests, including single max_results handling

## Tests
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest