### PR TITLE
feat: configure BGE embedding profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ Edit `configs/config.json`:
     "vectorizer": {
         "module_name": "huggingface_embed",
         "class_name": "HuggingFaceEmbedding",
-        "model_name": "distilbert-base-uncased",
-        "cache_size": 1000
+        "model_name": "BAAI/bge-small-en-v1.5",
+        "cache_size": 1000,
+        "pooling_strategy": "auto",
+        "normalize_embeddings": "auto",
+        "max_length": 512
     },
     "top_k": 10,
     "log_level": "INFO"
@@ -65,6 +68,9 @@ Edit `configs/config.json`:
 | `vectorizer.class_name` | Class name for vectorizer |
 | `vectorizer.model_name` | Model name or local path |
 | `vectorizer.cache_size` | Maximum number of embeddings to cache |
+| `vectorizer.pooling_strategy` | Embedding pooling strategy (`auto`, `mean`, or `cls`) |
+| `vectorizer.normalize_embeddings` | Whether to L2-normalize embeddings (`auto`, `true`, or `false`) |
+| `vectorizer.max_length` | Maximum token length for embedding inputs |
 | `top_k` | Number of recommended papers |
 | `log_level` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) |
 

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -3,8 +3,11 @@
     "vectorizer": {
         "module_name": "huggingface_embed",
         "class_name": "HuggingFaceEmbedding",
-        "model_name": "distilbert-base-uncased",
-        "cache_size": 1000
+        "model_name": "BAAI/bge-small-en-v1.5",
+        "cache_size": 1000,
+        "pooling_strategy": "auto",
+        "normalize_embeddings": "auto",
+        "max_length": 512
     },
     "top_k": 10,
     "log_level": "INFO"

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -3,7 +3,7 @@
 Objective review of the current `arxiv_recommender` codebase, focused on correctness, maintainability, ML quality, testing, and operational readiness.
 
 - Reviewed on: 2026-05-25
-- Updated on: 2026-06-06 after PR #32
+- Updated on: 2026-07-07 after PR #35
 - Scope: current codebase snapshot
 - Context: local CLI or localhost app priority
 
@@ -14,22 +14,29 @@ This document is a review snapshot, not a final verdict. Priority should follow 
 - `uv run ruff check .`: passed.
 - `uv run ruff format --check .`: passed.
 - `uv run python -m mypy src`: passed.
-- `uv run python -m pytest`: passed, 117 tests.
+- `uv run python -m pytest`: passed, 138 tests.
 
 ## Priority Findings
 
 These findings describe the main engineering and ML risks in the current codebase. Their importance does not change, but the order of implementation should follow the product goal. For a local user-facing app, retrieval quality still matters; batching and larger-scale performance tuning can move later if current runtime is acceptable.
 
-### High: Recommendation Quality Is Not ML-Validated
+### Partially Resolved: Recommendation Quality Is Not ML-Validated
 
-The recommender currently uses raw mean-pooled Hugging Face model outputs from `AutoModel`. DistilBERT is not trained as a sentence embedding model, so semantic similarity quality may be weak even if tests pass.
+PR #35 replaced the default raw DistilBERT configuration with a BGE-small
+embedding profile. `BAAI/bge-small-en-v1.5` now resolves to CLS pooling with
+L2-normalized embeddings, and cache entries are versioned by resolved embedding
+configuration.
+
+The remaining gap is evaluation: recommendation quality is still not validated
+against explicit user feedback or a retrieval benchmark.
 
 Recommended improvements:
 
 - Add an offline evaluation harness with labeled or proxy relevance data.
 - Track metrics such as recall@k, NDCG@k, MRR, and diversity.
 - Compare against simple baselines such as TF-IDF/BM25 before changing models.
-- Consider sentence-transformer or arXiv-domain embedding models if evaluation shows improvement.
+- Compare BGE-small with SPECTER2 and TF-IDF after enough eligible feedback
+  exists.
 
 Relevant code:
 

--- a/docs/decisions/0003-initial-bge-embedding-model.md
+++ b/docs/decisions/0003-initial-bge-embedding-model.md
@@ -48,6 +48,22 @@ embedding contract.
 - Model quality is provisional until explicit user feedback supports a
   chronological comparison.
 
+## Implementation Status
+
+Implemented in PR #35.
+
+- The example configuration uses `BAAI/bge-small-en-v1.5`.
+- `auto` embedding settings resolve through a model profile.
+- The BGE-small profile uses CLS pooling and L2 normalization.
+- Explicit settings that conflict with the BGE-small profile are rejected.
+- In-memory embedding cache entries are namespaced by the resolved embedding
+  configuration.
+- Focused tests cover profile resolution, pooling, normalization, and cache
+  version separation.
+
+Representative embedding latency measurement remains tracked in
+`docs/roadmap.md`.
+
 ## Revisit When
 
 Revisit the active embedding model after enough explicit feedback exists to

--- a/docs/personalized_recommender_design.md
+++ b/docs/personalized_recommender_design.md
@@ -69,6 +69,12 @@ local web interface
 of the title and abstract. Embeddings are L2-normalized and cached with an
 identifier that includes the model and embedding configuration.
 
+Embedding configuration is resolved before inference. User-facing config may
+use `auto` for pooling and normalization, but runtime embedding metadata uses
+the resolved values. The BGE-small profile resolves to CLS pooling with
+L2-normalized embeddings. Known model profiles reject incompatible explicit
+settings so cached embeddings and later evaluation remain reproducible.
+
 ## Feedback Semantics
 
 Only explicit binary feedback is used as a training or evaluation label:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,10 +5,10 @@ recommender. Accepted decisions are recorded separately in `docs/decisions/`.
 
 ## Milestone 1: Retrieval Embedding Foundation
 
-- [ ] Integrate `BAAI/bge-small-en-v1.5` with model-appropriate pooling.
-- [ ] L2-normalize embeddings and verify similarity behavior.
-- [ ] Version cache entries by model and embedding configuration.
-- [ ] Add focused unit tests for pooling, normalization, and caching.
+- [x] Integrate `BAAI/bge-small-en-v1.5` with model-appropriate pooling.
+- [x] L2-normalize embeddings and verify similarity behavior.
+- [x] Version cache entries by model and embedding configuration.
+- [x] Add focused unit tests for pooling, normalization, and caching.
 - [ ] Measure embedding latency on representative title-and-abstract inputs.
 
 ## Milestone 2: Local Feedback Vertical Slice

--- a/src/arxiv_recommender/cli.py
+++ b/src/arxiv_recommender/cli.py
@@ -59,6 +59,11 @@ def main() -> None:
         class_name=config.vectorizer.class_name,
         model_name=config.vectorizer.model_name,
         cache_size=config.vectorizer.cache_size,
+        vectorizer_options={
+            "pooling_strategy": config.vectorizer.pooling_strategy,
+            "normalize_embeddings": config.vectorizer.normalize_embeddings,
+            "max_length": config.vectorizer.max_length,
+        },
     )
     metrics = MetricsCollector()
     favorite_papers_provider = FileFavoritePapersProvider(

--- a/src/arxiv_recommender/embedding_config.py
+++ b/src/arxiv_recommender/embedding_config.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class PoolingStrategy(str, Enum):
+    """Supported token pooling strategies for HuggingFace hidden states."""
+
+    AUTO = "auto"
+    MEAN = "mean"
+    CLS = "cls"
+
+
+class AutoSetting(str, Enum):
+    """Automatic configuration sentinel for non-string embedding settings."""
+
+    AUTO = "auto"
+
+
+NormalizeEmbeddings = bool | AutoSetting
+
+
+@dataclass(frozen=True)
+class EmbeddingProfile:
+    """Embedding contract for a known model."""
+
+    pooling_strategy: PoolingStrategy
+    normalize_embeddings: bool
+
+
+@dataclass(frozen=True)
+class ResolvedEmbeddingConfig:
+    """Concrete embedding settings after resolving auto values."""
+
+    pooling_strategy: PoolingStrategy
+    normalize_embeddings: bool
+
+    def cache_namespace(self, model_name: str, max_length: int) -> str:
+        """Return a stable cache namespace for this embedding configuration."""
+        return (
+            f"model={model_name}|pooling={self.pooling_strategy.value}|"
+            f"normalize={self.normalize_embeddings}|max_length={max_length}"
+        )
+
+
+MODEL_EMBEDDING_PROFILES = {
+    "BAAI/bge-small-en-v1.5": EmbeddingProfile(
+        pooling_strategy=PoolingStrategy.CLS,
+        normalize_embeddings=True,
+    ),
+}
+
+
+def resolve_embedding_config(
+    model_name: str,
+    pooling_strategy: PoolingStrategy | str = PoolingStrategy.AUTO,
+    normalize_embeddings: NormalizeEmbeddings | str = AutoSetting.AUTO,
+) -> ResolvedEmbeddingConfig:
+    """Resolve and validate model-specific embedding settings.
+
+    Args:
+        model_name: HuggingFace model path or identifier.
+        pooling_strategy: Requested pooling strategy, or auto.
+        normalize_embeddings: Requested L2-normalization setting, or auto.
+
+    Returns:
+        Concrete embedding settings.
+
+    Raises:
+        ValueError: If a known model is configured against its embedding contract.
+    """
+    requested_pooling = PoolingStrategy(pooling_strategy)
+    requested_normalize = _coerce_normalize_embeddings(normalize_embeddings)
+
+    profile = MODEL_EMBEDDING_PROFILES.get(model_name)
+    default_pooling = profile.pooling_strategy if profile else PoolingStrategy.MEAN
+    default_normalize = profile.normalize_embeddings if profile else False
+
+    resolved_config = ResolvedEmbeddingConfig(
+        pooling_strategy=default_pooling
+        if requested_pooling is PoolingStrategy.AUTO
+        else requested_pooling,
+        normalize_embeddings=default_normalize
+        if requested_normalize is AutoSetting.AUTO
+        else bool(requested_normalize),
+    )
+
+    if profile:
+        _validate_known_model_config(model_name, profile, resolved_config)
+
+    return resolved_config
+
+
+def _coerce_normalize_embeddings(value: NormalizeEmbeddings | str) -> NormalizeEmbeddings:
+    if isinstance(value, bool):
+        return value
+    return AutoSetting(value)
+
+
+def _validate_known_model_config(
+    model_name: str,
+    profile: EmbeddingProfile,
+    resolved_config: ResolvedEmbeddingConfig,
+) -> None:
+    errors = []
+    if resolved_config.pooling_strategy is not profile.pooling_strategy:
+        errors.append(
+            "pooling_strategy must be "
+            f"'{profile.pooling_strategy.value}', got '{resolved_config.pooling_strategy.value}'"
+        )
+    if resolved_config.normalize_embeddings != profile.normalize_embeddings:
+        errors.append(
+            "normalize_embeddings must be "
+            f"{profile.normalize_embeddings}, got {resolved_config.normalize_embeddings}"
+        )
+
+    if errors:
+        raise ValueError(f"{model_name} embedding config is incompatible: {'; '.join(errors)}.")

--- a/src/arxiv_recommender/embedding_config.py
+++ b/src/arxiv_recommender/embedding_config.py
@@ -16,7 +16,7 @@ class AutoSetting(str, Enum):
     AUTO = "auto"
 
 
-NormalizeEmbeddings = bool | AutoSetting
+NormalizeEmbeddingsSetting = bool | AutoSetting
 
 
 @dataclass(frozen=True)
@@ -53,7 +53,7 @@ MODEL_EMBEDDING_PROFILES = {
 def resolve_embedding_config(
     model_name: str,
     pooling_strategy: PoolingStrategy | str = PoolingStrategy.AUTO,
-    normalize_embeddings: NormalizeEmbeddings | str = AutoSetting.AUTO,
+    normalize_embeddings: NormalizeEmbeddingsSetting | str = AutoSetting.AUTO,
 ) -> ResolvedEmbeddingConfig:
     """Resolve and validate model-specific embedding settings.
 
@@ -90,7 +90,9 @@ def resolve_embedding_config(
     return resolved_config
 
 
-def _coerce_normalize_embeddings(value: NormalizeEmbeddings | str) -> NormalizeEmbeddings:
+def _coerce_normalize_embeddings(
+    value: NormalizeEmbeddingsSetting | str,
+) -> NormalizeEmbeddingsSetting:
     if isinstance(value, bool):
         return value
     return AutoSetting(value)

--- a/src/arxiv_recommender/schemas/config.py
+++ b/src/arxiv_recommender/schemas/config.py
@@ -1,11 +1,11 @@
-from typing import Literal
-
 from pydantic import BaseModel, Field, field_validator
 
+from arxiv_recommender.embedding_config import (
+    AutoSetting,
+    NormalizeEmbeddings,
+    PoolingStrategy,
+)
 from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
-
-EmbeddingPoolingStrategy = Literal["auto", "mean", "cls"]
-NormalizeEmbeddings = bool | Literal["auto"]
 
 
 class VectorizerConfig(BaseModel):
@@ -17,12 +17,12 @@ class VectorizerConfig(BaseModel):
         ge=0,
         description="Maximum number of embeddings to cache",
     )
-    pooling_strategy: EmbeddingPoolingStrategy = Field(
-        default="auto",
+    pooling_strategy: PoolingStrategy = Field(
+        default=PoolingStrategy.AUTO,
         description="Embedding pooling strategy, or auto for known model profiles",
     )
     normalize_embeddings: NormalizeEmbeddings = Field(
-        default="auto",
+        default=AutoSetting.AUTO,
         description="Whether to L2-normalize embeddings, or auto for known model profiles",
     )
     max_length: int = Field(

--- a/src/arxiv_recommender/schemas/config.py
+++ b/src/arxiv_recommender/schemas/config.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from arxiv_recommender.embedding_config import (
     AutoSetting,
-    NormalizeEmbeddings,
+    NormalizeEmbeddingsSetting,
     PoolingStrategy,
 )
 from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
@@ -21,7 +21,7 @@ class VectorizerConfig(BaseModel):
         default=PoolingStrategy.AUTO,
         description="Embedding pooling strategy, or auto for known model profiles",
     )
-    normalize_embeddings: NormalizeEmbeddings = Field(
+    normalize_embeddings: NormalizeEmbeddingsSetting = Field(
         default=AutoSetting.AUTO,
         description="Whether to L2-normalize embeddings, or auto for known model profiles",
     )

--- a/src/arxiv_recommender/schemas/config.py
+++ b/src/arxiv_recommender/schemas/config.py
@@ -1,6 +1,11 @@
+from typing import Literal
+
 from pydantic import BaseModel, Field, field_validator
 
 from arxiv_recommender.utils.logging import SUPPORTED_LOG_LEVELS
+
+EmbeddingPoolingStrategy = Literal["auto", "mean", "cls"]
+NormalizeEmbeddings = bool | Literal["auto"]
 
 
 class VectorizerConfig(BaseModel):
@@ -11,6 +16,19 @@ class VectorizerConfig(BaseModel):
         default=1000,
         ge=0,
         description="Maximum number of embeddings to cache",
+    )
+    pooling_strategy: EmbeddingPoolingStrategy = Field(
+        default="auto",
+        description="Embedding pooling strategy, or auto for known model profiles",
+    )
+    normalize_embeddings: NormalizeEmbeddings = Field(
+        default="auto",
+        description="Whether to L2-normalize embeddings, or auto for known model profiles",
+    )
+    max_length: int = Field(
+        default=512,
+        gt=0,
+        description="Maximum token length for embedding model inputs",
     )
 
     model_config = {"frozen": True}

--- a/src/arxiv_recommender/text_vectorization/cache.py
+++ b/src/arxiv_recommender/text_vectorization/cache.py
@@ -14,14 +14,16 @@ class EmbeddingCache:
         _cache (OrderedDict): Internal cache storage.
     """
 
-    def __init__(self, max_size: int = 1000) -> None:
+    def __init__(self, max_size: int = 1000, namespace: str = "default") -> None:
         """
         Initializes the embedding cache.
 
         Args:
             max_size (int): Maximum number of embeddings to store.
+            namespace (str): Cache namespace for embedding model/config versioning.
         """
         self.max_size = max_size
+        self.namespace = namespace
         self._cache: OrderedDict[str, np.ndarray] = OrderedDict()
         self._hits = 0
         self._misses = 0
@@ -36,7 +38,8 @@ class EmbeddingCache:
         Returns:
             str: SHA256 hash of the text.
         """
-        return hashlib.sha256(text.encode()).hexdigest()
+        cache_input = f"{self.namespace}\n{text}"
+        return hashlib.sha256(cache_input.encode()).hexdigest()
 
     def get(self, text: str) -> np.ndarray | None:
         """
@@ -91,5 +94,6 @@ class EmbeddingCache:
             "misses": self._misses,
             "size": len(self._cache),
             "max_size": self.max_size,
+            "namespace": self.namespace,
             "hit_rate": hit_rate,
         }

--- a/src/arxiv_recommender/text_vectorization/huggingface_embed.py
+++ b/src/arxiv_recommender/text_vectorization/huggingface_embed.py
@@ -1,22 +1,18 @@
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import numpy as np
 import torch
 from transformers import AutoModel, AutoTokenizer
 
+from arxiv_recommender.embedding_config import (
+    AutoSetting,
+    NormalizeEmbeddings,
+    PoolingStrategy,
+    resolve_embedding_config,
+)
 from arxiv_recommender.text_vectorization.base import TextEmbedder
 from arxiv_recommender.text_vectorization.cache import EmbeddingCache
-
-PoolingStrategy = Literal["auto", "mean", "cls"]
-ResolvedPoolingStrategy = Literal["mean", "cls"]
-NormalizeEmbeddings = bool | Literal["auto"]
-
-MODEL_EMBEDDING_PROFILES: dict[str, dict[str, ResolvedPoolingStrategy | bool]] = {
-    "BAAI/bge-small-en-v1.5": {
-        "pooling_strategy": "cls",
-        "normalize_embeddings": True,
-    },
-}
+from arxiv_recommender.text_vectorization.pooling import create_pooler
 
 
 class HuggingFaceEmbedding(TextEmbedder):
@@ -26,8 +22,8 @@ class HuggingFaceEmbedding(TextEmbedder):
         self,
         model_name: str = "distilbert-base-uncased",
         cache_size: int = 1000,
-        pooling_strategy: PoolingStrategy = "auto",
-        normalize_embeddings: NormalizeEmbeddings = "auto",
+        pooling_strategy: PoolingStrategy | str = PoolingStrategy.AUTO,
+        normalize_embeddings: NormalizeEmbeddings | str = AutoSetting.AUTO,
         max_length: int = 512,
     ) -> None:
         """Initializes tokenizer, model, and embedding cache.
@@ -40,19 +36,19 @@ class HuggingFaceEmbedding(TextEmbedder):
             max_length: Maximum token length for truncation.
         """
         self.model_name = model_name
-        self.pooling_strategy, self.normalize_embeddings = self._resolve_embedding_config(
+        self.embedding_config = resolve_embedding_config(
             model_name=model_name,
             pooling_strategy=pooling_strategy,
             normalize_embeddings=normalize_embeddings,
         )
+        self.pooling_strategy = self.embedding_config.pooling_strategy.value
+        self.normalize_embeddings = self.embedding_config.normalize_embeddings
+        self._pooler = create_pooler(self.embedding_config.pooling_strategy)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model = AutoModel.from_pretrained(model_name)
         self.model.eval()
         self.max_length = max_length
-        self.embedding_config_id = (
-            f"model={model_name}|pooling={self.pooling_strategy}|"
-            f"normalize={self.normalize_embeddings}|max_length={max_length}"
-        )
+        self.embedding_config_id = self.embedding_config.cache_namespace(model_name, max_length)
         self.cache = EmbeddingCache(max_size=cache_size, namespace=self.embedding_config_id)
 
     def process(self, text: str) -> np.ndarray:
@@ -107,50 +103,12 @@ class HuggingFaceEmbedding(TextEmbedder):
 
         embeddings = cast(torch.Tensor, outputs.last_hidden_state)
         attention_mask = tokenized_text["attention_mask"]
-        if self.pooling_strategy == "cls":
-            pooled_embeddings = embeddings[:, 0]
-        else:
-            pooled_embeddings = self._mean_pool(embeddings, attention_mask)
+        pooled_embeddings = self._pooler(embeddings, attention_mask)
 
         if self.normalize_embeddings:
             pooled_embeddings = torch.nn.functional.normalize(pooled_embeddings, p=2, dim=1)
 
         return pooled_embeddings[0]
-
-    def _mean_pool(self, embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
-        mask = attention_mask.unsqueeze(-1).expand(embeddings.size()).float()
-        masked_embeddings = embeddings * mask
-        summed_embeddings = torch.sum(masked_embeddings, dim=1)
-        token_counts = torch.clamp(mask.sum(dim=1), min=1e-9)
-        return summed_embeddings / token_counts
-
-    def _resolve_embedding_config(
-        self,
-        model_name: str,
-        pooling_strategy: PoolingStrategy,
-        normalize_embeddings: NormalizeEmbeddings,
-    ) -> tuple[ResolvedPoolingStrategy, bool]:
-        profile = MODEL_EMBEDDING_PROFILES.get(model_name)
-        default_pooling: ResolvedPoolingStrategy = "mean"
-        default_normalize = False
-        if profile:
-            default_pooling = cast(ResolvedPoolingStrategy, profile["pooling_strategy"])
-            default_normalize = bool(profile["normalize_embeddings"])
-
-        resolved_pooling = default_pooling if pooling_strategy == "auto" else pooling_strategy
-        resolved_normalize = (
-            default_normalize if normalize_embeddings == "auto" else normalize_embeddings
-        )
-
-        if profile and (
-            resolved_pooling != default_pooling or resolved_normalize != default_normalize
-        ):
-            raise ValueError(
-                f"{model_name} requires pooling_strategy='{default_pooling}' "
-                f"and normalize_embeddings={default_normalize}."
-            )
-
-        return resolved_pooling, resolved_normalize
 
     def get_cache_stats(self) -> dict[str, Any]:
         """Get cache performance statistics.

--- a/src/arxiv_recommender/text_vectorization/huggingface_embed.py
+++ b/src/arxiv_recommender/text_vectorization/huggingface_embed.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 import torch
@@ -7,27 +7,53 @@ from transformers import AutoModel, AutoTokenizer
 from arxiv_recommender.text_vectorization.base import TextEmbedder
 from arxiv_recommender.text_vectorization.cache import EmbeddingCache
 
+PoolingStrategy = Literal["auto", "mean", "cls"]
+ResolvedPoolingStrategy = Literal["mean", "cls"]
+NormalizeEmbeddings = bool | Literal["auto"]
+
+MODEL_EMBEDDING_PROFILES: dict[str, dict[str, ResolvedPoolingStrategy | bool]] = {
+    "BAAI/bge-small-en-v1.5": {
+        "pooling_strategy": "cls",
+        "normalize_embeddings": True,
+    },
+}
+
 
 class HuggingFaceEmbedding(TextEmbedder):
-    """Generic HuggingFace text embedder using mean pooled token embeddings."""
+    """Generic HuggingFace text embedder with model-aware embedding settings."""
 
     def __init__(
         self,
         model_name: str = "distilbert-base-uncased",
         cache_size: int = 1000,
+        pooling_strategy: PoolingStrategy = "auto",
+        normalize_embeddings: NormalizeEmbeddings = "auto",
+        max_length: int = 512,
     ) -> None:
         """Initializes tokenizer, model, and embedding cache.
 
         Args:
             model_name: HuggingFace model path or identifier.
             cache_size: Maximum number of embeddings to cache.
+            pooling_strategy: Token pooling strategy, or auto for known model profiles.
+            normalize_embeddings: Whether to L2-normalize embeddings, or auto for known profiles.
+            max_length: Maximum token length for truncation.
         """
         self.model_name = model_name
+        self.pooling_strategy, self.normalize_embeddings = self._resolve_embedding_config(
+            model_name=model_name,
+            pooling_strategy=pooling_strategy,
+            normalize_embeddings=normalize_embeddings,
+        )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model = AutoModel.from_pretrained(model_name)
         self.model.eval()
-        self.max_length = 512
-        self.cache = EmbeddingCache(max_size=cache_size)
+        self.max_length = max_length
+        self.embedding_config_id = (
+            f"model={model_name}|pooling={self.pooling_strategy}|"
+            f"normalize={self.normalize_embeddings}|max_length={max_length}"
+        )
+        self.cache = EmbeddingCache(max_size=cache_size, namespace=self.embedding_config_id)
 
     def process(self, text: str) -> np.ndarray:
         """Generate an embedding vector for the given text.
@@ -68,28 +94,63 @@ class HuggingFaceEmbedding(TextEmbedder):
         return cast(dict[str, torch.Tensor], tokenized_text)
 
     def vectorize(self, tokenized_text: dict[str, torch.Tensor]) -> torch.Tensor:
-        """Get embedding vectors for tokenized text with attention-aware mean pooling.
+        """Get embedding vectors for tokenized text.
 
         Args:
             tokenized_text: Tokenized HuggingFace model inputs.
 
         Returns:
-            Mean pooled text embedding as tensor.
+            Text embedding as tensor.
         """
         with torch.no_grad():
             outputs = self.model(**tokenized_text)
 
-        embeddings = outputs.last_hidden_state
+        embeddings = cast(torch.Tensor, outputs.last_hidden_state)
         attention_mask = tokenized_text["attention_mask"]
-        return self._mean_pool(embeddings, attention_mask)
+        if self.pooling_strategy == "cls":
+            pooled_embeddings = embeddings[:, 0]
+        else:
+            pooled_embeddings = self._mean_pool(embeddings, attention_mask)
+
+        if self.normalize_embeddings:
+            pooled_embeddings = torch.nn.functional.normalize(pooled_embeddings, p=2, dim=1)
+
+        return pooled_embeddings[0]
 
     def _mean_pool(self, embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         mask = attention_mask.unsqueeze(-1).expand(embeddings.size()).float()
         masked_embeddings = embeddings * mask
         summed_embeddings = torch.sum(masked_embeddings, dim=1)
         token_counts = torch.clamp(mask.sum(dim=1), min=1e-9)
-        sentence_embeddings = summed_embeddings / token_counts
-        return torch.mean(sentence_embeddings, dim=0, keepdim=False)
+        return summed_embeddings / token_counts
+
+    def _resolve_embedding_config(
+        self,
+        model_name: str,
+        pooling_strategy: PoolingStrategy,
+        normalize_embeddings: NormalizeEmbeddings,
+    ) -> tuple[ResolvedPoolingStrategy, bool]:
+        profile = MODEL_EMBEDDING_PROFILES.get(model_name)
+        default_pooling: ResolvedPoolingStrategy = "mean"
+        default_normalize = False
+        if profile:
+            default_pooling = cast(ResolvedPoolingStrategy, profile["pooling_strategy"])
+            default_normalize = bool(profile["normalize_embeddings"])
+
+        resolved_pooling = default_pooling if pooling_strategy == "auto" else pooling_strategy
+        resolved_normalize = (
+            default_normalize if normalize_embeddings == "auto" else normalize_embeddings
+        )
+
+        if profile and (
+            resolved_pooling != default_pooling or resolved_normalize != default_normalize
+        ):
+            raise ValueError(
+                f"{model_name} requires pooling_strategy='{default_pooling}' "
+                f"and normalize_embeddings={default_normalize}."
+            )
+
+        return resolved_pooling, resolved_normalize
 
     def get_cache_stats(self) -> dict[str, Any]:
         """Get cache performance statistics.

--- a/src/arxiv_recommender/text_vectorization/huggingface_embed.py
+++ b/src/arxiv_recommender/text_vectorization/huggingface_embed.py
@@ -6,7 +6,7 @@ from transformers import AutoModel, AutoTokenizer
 
 from arxiv_recommender.embedding_config import (
     AutoSetting,
-    NormalizeEmbeddings,
+    NormalizeEmbeddingsSetting,
     PoolingStrategy,
     resolve_embedding_config,
 )
@@ -23,7 +23,7 @@ class HuggingFaceEmbedding(TextEmbedder):
         model_name: str = "distilbert-base-uncased",
         cache_size: int = 1000,
         pooling_strategy: PoolingStrategy | str = PoolingStrategy.AUTO,
-        normalize_embeddings: NormalizeEmbeddings | str = AutoSetting.AUTO,
+        normalize_embeddings: NormalizeEmbeddingsSetting | str = AutoSetting.AUTO,
         max_length: int = 512,
     ) -> None:
         """Initializes tokenizer, model, and embedding cache.

--- a/src/arxiv_recommender/text_vectorization/pooling.py
+++ b/src/arxiv_recommender/text_vectorization/pooling.py
@@ -1,0 +1,32 @@
+from collections.abc import Callable
+
+import torch
+
+from arxiv_recommender.embedding_config import PoolingStrategy
+
+Pooler = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+
+
+def create_pooler(pooling_strategy: PoolingStrategy) -> Pooler:
+    """Create a token pooler for HuggingFace hidden states."""
+    if pooling_strategy is PoolingStrategy.CLS:
+        return cls_pool
+    if pooling_strategy is PoolingStrategy.MEAN:
+        return mean_pool
+
+    raise ValueError(f"Unsupported pooling strategy: {pooling_strategy.value}")
+
+
+def cls_pool(embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+    """Use the first token hidden state as the text embedding."""
+    del attention_mask
+    return embeddings[:, 0]
+
+
+def mean_pool(embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+    """Average non-padding token hidden states."""
+    mask = attention_mask.unsqueeze(-1).expand(embeddings.size()).float()
+    masked_embeddings = embeddings * mask
+    summed_embeddings = torch.sum(masked_embeddings, dim=1)
+    token_counts = torch.clamp(mask.sum(dim=1), min=1e-9)
+    return summed_embeddings / token_counts

--- a/src/arxiv_recommender/utils/model_loader.py
+++ b/src/arxiv_recommender/utils/model_loader.py
@@ -15,6 +15,7 @@ def load_vectorization_model(
     class_name: str,
     model_name: str,
     cache_size: int,
+    vectorizer_options: dict[str, Any] | None = None,
 ) -> TextEmbedder:
     """
     Dynamically loads a text vectorization model.
@@ -24,6 +25,7 @@ def load_vectorization_model(
         class_name (str): Name of the model class to load.
         model_name (str): Name of the model to load.
         cache_size (int): Maximum number of embeddings to cache.
+        vectorizer_options: Additional keyword arguments for the vectorizer.
 
     Returns:
         Instantiated text embedder.
@@ -55,7 +57,7 @@ def load_vectorization_model(
     model_class = _get_vectorizer_class(module, class_name, full_module_name)
 
     try:
-        model = model_class(model_name, cache_size=cache_size)
+        model = model_class(model_name, cache_size=cache_size, **(vectorizer_options or {}))
     except Exception as exc:
         logging.error(
             "Failed to instantiate vectorizer '%s.%s' with model '%s': %s",

--- a/tests/schemas/test_config.py
+++ b/tests/schemas/test_config.py
@@ -15,6 +15,9 @@ class TestVectorizerConfig:
         assert config.module_name == "distil_bert"
         assert config.class_name == "DistilBERTEmbedding"
         assert config.model_name == "distilbert-base-uncased"
+        assert config.pooling_strategy == "auto"
+        assert config.normalize_embeddings == "auto"
+        assert config.max_length == 512
 
     def test_vectorizer_is_frozen(self) -> None:
         """Test that VectorizerConfig is immutable."""
@@ -53,6 +56,43 @@ class TestVectorizerConfig:
             cache_size=0,
         )
         assert config.cache_size == 0
+
+    def test_vectorizer_accepts_embedding_options(self) -> None:
+        """Test configurable embedding pooling and normalization options."""
+        config = VectorizerConfig(
+            module_name="huggingface_embed",
+            class_name="HuggingFaceEmbedding",
+            model_name="BAAI/bge-small-en-v1.5",
+            pooling_strategy="cls",
+            normalize_embeddings=True,
+            max_length=256,
+        )
+
+        assert config.pooling_strategy == "cls"
+        assert config.normalize_embeddings is True
+        assert config.max_length == 256
+
+    def test_vectorizer_rejects_invalid_pooling_strategy(self) -> None:
+        """Test that pooling_strategy is restricted to supported values."""
+        with pytest.raises(Exception):
+            VectorizerConfig.model_validate(
+                {
+                    "module_name": "test",
+                    "class_name": "TestClass",
+                    "model_name": "test-model",
+                    "pooling_strategy": "max",
+                }
+            )
+
+    def test_vectorizer_rejects_non_positive_max_length(self) -> None:
+        """Test that max_length must be positive."""
+        with pytest.raises(Exception):
+            VectorizerConfig(
+                module_name="test",
+                class_name="TestClass",
+                model_name="test-model",
+                max_length=0,
+            )
 
 
 class TestAppConfig:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,11 @@ class TestCli(unittest.TestCase):
             class_name=self.config.vectorizer.class_name,
             model_name=self.config.vectorizer.model_name,
             cache_size=self.config.vectorizer.cache_size,
+            vectorizer_options={
+                "pooling_strategy": self.config.vectorizer.pooling_strategy,
+                "normalize_embeddings": self.config.vectorizer.normalize_embeddings,
+                "max_length": self.config.vectorizer.max_length,
+            },
         )
         mock_provider_class.assert_called_once_with(
             favorite_papers_path=self.config.favorite_papers_path,

--- a/tests/text_vectorization/test_cache.py
+++ b/tests/text_vectorization/test_cache.py
@@ -1,16 +1,17 @@
 import unittest
+
 import numpy as np
 
 from arxiv_recommender.text_vectorization.cache import EmbeddingCache
 
 
 class TestEmbeddingCache(unittest.TestCase):
-    def test_cache_miss_returns_none(self):
+    def test_cache_miss_returns_none(self) -> None:
         cache = EmbeddingCache(max_size=10)
         result = cache.get("some text")
         self.assertIsNone(result)
 
-    def test_cache_hit_returns_embedding(self):
+    def test_cache_hit_returns_embedding(self) -> None:
         cache = EmbeddingCache(max_size=10)
         embedding = np.array([1.0, 2.0, 3.0])
         cache.put("test text", embedding)
@@ -18,7 +19,7 @@ class TestEmbeddingCache(unittest.TestCase):
         self.assertIsNotNone(result)
         np.testing.assert_array_equal(result, embedding)
 
-    def test_cache_eviction_lru(self):
+    def test_cache_eviction_lru(self) -> None:
         cache = EmbeddingCache(max_size=2)
         cache.put("text1", np.array([1.0]))
         cache.put("text2", np.array([2.0]))
@@ -27,7 +28,7 @@ class TestEmbeddingCache(unittest.TestCase):
         self.assertIsNone(cache.get("text2"))
         self.assertIsNotNone(cache.get("text1"))
 
-    def test_clear_resets_stats(self):
+    def test_clear_resets_stats(self) -> None:
         cache = EmbeddingCache(max_size=10)
         cache.put("text", np.array([1.0]))
         cache.get("text")
@@ -37,7 +38,7 @@ class TestEmbeddingCache(unittest.TestCase):
         self.assertEqual(cache.stats()["misses"], 0)
         self.assertEqual(cache.stats()["size"], 0)
 
-    def test_stats_calculation(self):
+    def test_stats_calculation(self) -> None:
         cache = EmbeddingCache(max_size=10)
         cache.put("text1", np.array([1.0]))
         cache.get("text1")
@@ -47,9 +48,19 @@ class TestEmbeddingCache(unittest.TestCase):
         self.assertEqual(stats["misses"], 1)
         self.assertEqual(stats["size"], 1)
         self.assertEqual(stats["max_size"], 10)
+        self.assertEqual(stats["namespace"], "default")
         self.assertEqual(stats["hit_rate"], 0.5)
 
-    def test_same_text_returns_hit(self):
+    def test_namespace_separates_cache_keys(self) -> None:
+        first_cache = EmbeddingCache(max_size=10, namespace="model-a")
+        second_cache = EmbeddingCache(max_size=10, namespace="model-b")
+
+        self.assertNotEqual(
+            first_cache._compute_key("same text"),
+            second_cache._compute_key("same text"),
+        )
+
+    def test_same_text_returns_hit(self) -> None:
         cache = EmbeddingCache(max_size=10)
         embedding = np.array([1.0, 2.0, 3.0])
         cache.put("test", embedding)
@@ -59,7 +70,7 @@ class TestEmbeddingCache(unittest.TestCase):
         self.assertEqual(stats["hits"], 2)
         self.assertEqual(stats["misses"], 0)
 
-    def test_cache_hit_moves_key_to_end(self):
+    def test_cache_hit_moves_key_to_end(self) -> None:
         cache = EmbeddingCache(max_size=3)
         cache.put("a", np.array([1.0]))
         cache.put("b", np.array([2.0]))

--- a/tests/text_vectorization/test_embedding_config.py
+++ b/tests/text_vectorization/test_embedding_config.py
@@ -1,0 +1,70 @@
+import pytest
+
+from arxiv_recommender.embedding_config import (
+    AutoSetting,
+    PoolingStrategy,
+    resolve_embedding_config,
+)
+
+
+def test_unknown_model_auto_uses_default_embedding_config() -> None:
+    config = resolve_embedding_config("unknown-model")
+
+    assert config.pooling_strategy is PoolingStrategy.MEAN
+    assert config.normalize_embeddings is False
+
+
+def test_unknown_model_allows_explicit_embedding_config() -> None:
+    config = resolve_embedding_config(
+        "unknown-model",
+        pooling_strategy=PoolingStrategy.CLS,
+        normalize_embeddings=True,
+    )
+
+    assert config.pooling_strategy is PoolingStrategy.CLS
+    assert config.normalize_embeddings is True
+
+
+def test_bge_small_auto_uses_profile_embedding_config() -> None:
+    config = resolve_embedding_config("BAAI/bge-small-en-v1.5")
+
+    assert config.pooling_strategy is PoolingStrategy.CLS
+    assert config.normalize_embeddings is True
+
+
+def test_bge_small_allows_matching_explicit_embedding_config() -> None:
+    config = resolve_embedding_config(
+        "BAAI/bge-small-en-v1.5",
+        pooling_strategy="cls",
+        normalize_embeddings=True,
+    )
+
+    assert config.pooling_strategy is PoolingStrategy.CLS
+    assert config.normalize_embeddings is True
+
+
+def test_bge_small_rejects_incorrect_explicit_pooling() -> None:
+    with pytest.raises(ValueError, match="pooling_strategy must be 'cls', got 'mean'"):
+        resolve_embedding_config(
+            "BAAI/bge-small-en-v1.5",
+            pooling_strategy=PoolingStrategy.MEAN,
+            normalize_embeddings=AutoSetting.AUTO,
+        )
+
+
+def test_bge_small_rejects_incorrect_explicit_normalization() -> None:
+    with pytest.raises(ValueError, match="normalize_embeddings must be True, got False"):
+        resolve_embedding_config(
+            "BAAI/bge-small-en-v1.5",
+            pooling_strategy=PoolingStrategy.AUTO,
+            normalize_embeddings=False,
+        )
+
+
+def test_cache_namespace_uses_resolved_embedding_values() -> None:
+    config = resolve_embedding_config("BAAI/bge-small-en-v1.5")
+
+    assert (
+        config.cache_namespace("BAAI/bge-small-en-v1.5", max_length=512)
+        == "model=BAAI/bge-small-en-v1.5|pooling=cls|normalize=True|max_length=512"
+    )

--- a/tests/text_vectorization/test_huggingface_embed.py
+++ b/tests/text_vectorization/test_huggingface_embed.py
@@ -93,7 +93,7 @@ class TestHuggingFaceEmbedding(unittest.TestCase):
     def test_bge_small_rejects_incorrect_explicit_pooling(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
-            "BAAI/bge-small-en-v1.5 requires pooling_strategy='cls'",
+            "pooling_strategy must be 'cls', got 'mean'",
         ):
             HuggingFaceEmbedding(
                 "BAAI/bge-small-en-v1.5",
@@ -104,7 +104,7 @@ class TestHuggingFaceEmbedding(unittest.TestCase):
     def test_bge_small_rejects_incorrect_explicit_normalization(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
-            "BAAI/bge-small-en-v1.5 requires pooling_strategy='cls'",
+            "normalize_embeddings must be True, got False",
         ):
             HuggingFaceEmbedding(
                 "BAAI/bge-small-en-v1.5",

--- a/tests/text_vectorization/test_huggingface_embed.py
+++ b/tests/text_vectorization/test_huggingface_embed.py
@@ -62,6 +62,101 @@ class TestHuggingFaceEmbedding(unittest.TestCase):
         mock_model.assert_called_once()
         self.assertEqual(embedder.get_cache_stats()["hits"], 1)
 
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_unknown_model_auto_uses_mean_pooling_without_normalization(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        mock_tokenizer_from_pretrained.return_value = MagicMock()
+        mock_model_from_pretrained.return_value = MagicMock()
+
+        embedder = HuggingFaceEmbedding("test-model")
+
+        self.assertEqual(embedder.pooling_strategy, "mean")
+        self.assertFalse(embedder.normalize_embeddings)
+
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_bge_small_auto_uses_profile_settings(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        mock_tokenizer_from_pretrained.return_value = MagicMock()
+        mock_model_from_pretrained.return_value = MagicMock()
+
+        embedder = HuggingFaceEmbedding("BAAI/bge-small-en-v1.5")
+
+        self.assertEqual(embedder.pooling_strategy, "cls")
+        self.assertTrue(embedder.normalize_embeddings)
+        self.assertIn("pooling=cls", embedder.embedding_config_id)
+        self.assertIn("normalize=True", embedder.embedding_config_id)
+
+    def test_bge_small_rejects_incorrect_explicit_pooling(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "BAAI/bge-small-en-v1.5 requires pooling_strategy='cls'",
+        ):
+            HuggingFaceEmbedding(
+                "BAAI/bge-small-en-v1.5",
+                pooling_strategy="mean",
+                normalize_embeddings=True,
+            )
+
+    def test_bge_small_rejects_incorrect_explicit_normalization(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "BAAI/bge-small-en-v1.5 requires pooling_strategy='cls'",
+        ):
+            HuggingFaceEmbedding(
+                "BAAI/bge-small-en-v1.5",
+                pooling_strategy="cls",
+                normalize_embeddings=False,
+            )
+
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_process_can_return_normalized_cls_embedding(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.tensor([[101, 102]]),
+            "attention_mask": torch.tensor([[1, 1]]),
+        }
+        mock_tokenizer_from_pretrained.return_value = mock_tokenizer
+
+        mock_model = MagicMock()
+        mock_output = MagicMock()
+        mock_output.last_hidden_state = torch.tensor([[[3.0, 4.0], [100.0, 100.0]]])
+        mock_model.return_value = mock_output
+        mock_model_from_pretrained.return_value = mock_model
+
+        embedder = HuggingFaceEmbedding(
+            "test-model",
+            pooling_strategy="cls",
+            normalize_embeddings=True,
+        )
+        embedding = embedder.process("sample text")
+
+        np.testing.assert_allclose(embedding, np.array([0.6, 0.8], dtype=np.float32))
+        self.assertAlmostEqual(float(np.linalg.norm(embedding)), 1.0)
+
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoModel.from_pretrained")
+    @patch("arxiv_recommender.text_vectorization.huggingface_embed.AutoTokenizer.from_pretrained")
+    def test_embedding_config_versions_cache_namespace(
+        self, mock_tokenizer_from_pretrained: Any, mock_model_from_pretrained: Any
+    ) -> None:
+        mock_tokenizer_from_pretrained.return_value = MagicMock()
+        mock_model_from_pretrained.return_value = MagicMock()
+
+        mean_embedder = HuggingFaceEmbedding("test-model", pooling_strategy="mean")
+        cls_embedder = HuggingFaceEmbedding("test-model", pooling_strategy="cls")
+
+        self.assertNotEqual(mean_embedder.embedding_config_id, cls_embedder.embedding_config_id)
+        self.assertNotEqual(
+            mean_embedder.cache._compute_key("same text"),
+            cls_embedder.cache._compute_key("same text"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/text_vectorization/test_pooling.py
+++ b/tests/text_vectorization/test_pooling.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+from arxiv_recommender.embedding_config import PoolingStrategy
+from arxiv_recommender.text_vectorization.pooling import create_pooler
+
+
+def test_create_pooler_returns_cls_pooler() -> None:
+    embeddings = torch.tensor([[[3.0, 4.0], [100.0, 100.0]]])
+    attention_mask = torch.tensor([[1, 1]])
+
+    pooler = create_pooler(PoolingStrategy.CLS)
+
+    torch.testing.assert_close(pooler(embeddings, attention_mask), torch.tensor([[3.0, 4.0]]))
+
+
+def test_create_pooler_returns_attention_aware_mean_pooler() -> None:
+    embeddings = torch.tensor([[[1.0, 3.0], [3.0, 5.0], [100.0, 100.0]]])
+    attention_mask = torch.tensor([[1, 1, 0]])
+
+    pooler = create_pooler(PoolingStrategy.MEAN)
+
+    torch.testing.assert_close(pooler(embeddings, attention_mask), torch.tensor([[2.0, 4.0]]))
+
+
+def test_create_pooler_rejects_auto_strategy() -> None:
+    with pytest.raises(ValueError, match="Unsupported pooling strategy: auto"):
+        create_pooler(PoolingStrategy.AUTO)

--- a/tests/utils/test_model_loader.py
+++ b/tests/utils/test_model_loader.py
@@ -13,9 +13,10 @@ from arxiv_recommender.utils.model_loader import (
 
 
 class FakeEmbedder(TextEmbedder):
-    def __init__(self, model_name: str, cache_size: int) -> None:
+    def __init__(self, model_name: str, cache_size: int, **kwargs: Any) -> None:
         self.model_name = model_name
         self.cache_size = cache_size
+        self.kwargs = kwargs
 
     def process(self, text: str) -> np.ndarray:
         return np.array([len(text)])
@@ -81,6 +82,36 @@ class TestModelLoader(unittest.TestCase):
         fake_vectorizer = cast(FakeEmbedder, vectorizer)
         self.assertEqual(fake_vectorizer.model_name, "custom_vectorinzer_model_name")
         self.assertEqual(fake_vectorizer.cache_size, 1000)
+
+    @patch("importlib.import_module")
+    def test_load_vectorizer_passes_options(self, mock_import: Any) -> None:
+        """
+        Test passing optional vectorizer settings to the configured class.
+        """
+        mock_module = SimpleNamespace(CustomVectorizer=FakeEmbedder)
+        mock_import.return_value = mock_module
+
+        vectorizer = load_vectorization_model(
+            "custom_vectorizer",
+            "CustomVectorizer",
+            "custom_model",
+            1000,
+            vectorizer_options={
+                "pooling_strategy": "cls",
+                "normalize_embeddings": True,
+                "max_length": 256,
+            },
+        )
+
+        fake_vectorizer = cast(FakeEmbedder, vectorizer)
+        self.assertEqual(
+            fake_vectorizer.kwargs,
+            {
+                "pooling_strategy": "cls",
+                "normalize_embeddings": True,
+                "max_length": 256,
+            },
+        )
 
     @patch("importlib.import_module")
     def test_load_missing_vectorizer_module(self, mock_import: Any) -> None:


### PR DESCRIPTION
## Summary
- add configurable pooling, normalization, and max-length vectorizer settings
- resolve BGE-small auto settings to CLS pooling with L2 normalization and reject incorrect explicit BGE configs
- version embedding cache keys by resolved embedding configuration
- update example config and README to use BGE-small

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest