### PR TITLE
chore: add embedding latency benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ arxiv_recommender/
 │       └── utils/                    # Utility functions
 ├── configs/
 │   └── config.json.example           # Configuration template
+├── benchmarks/                       # Local engineering benchmarks
 ├── tests/                            # Unit tests
 ├── pyproject.toml                    # Project configuration
 └── README.md                         # Project documentation
@@ -127,6 +128,21 @@ If `favorite_papers.json` is missing or empty, the CLI will prompt you to enter 
 ```bash
 uv run python -m pytest
 ```
+
+## Benchmarking
+
+Measure embedding latency for representative title-and-abstract inputs:
+
+```bash
+uv run python benchmarks/embedding_latency.py \
+  --config configs/config.json \
+  --sizes 1 10 100 \
+  --repeats 3 \
+  --warmup 1
+```
+
+Benchmark results are local-machine-specific and are intended for comparing
+future model or embedding-pipeline changes.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ Measure embedding latency for representative title-and-abstract inputs:
 uv run python benchmarks/embedding_latency.py \
   --config configs/config.json \
   --sizes 1 10 100 \
-  --repeats 3 \
-  --warmup 1
+  --repeats 3
 ```
 
 Benchmark results are local-machine-specific and are intended for comparing

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,8 +12,7 @@ title-and-abstract inputs on the current machine:
 uv run python benchmarks/embedding_latency.py \
   --config configs/config.json \
   --sizes 1 10 100 \
-  --repeats 3 \
-  --warmup 1
+  --repeats 3
 ```
 
 The benchmark disables the embedding cache so results reflect model inference
@@ -21,6 +20,10 @@ latency rather than cache hits.
 
 The output is JSON and includes model configuration, local runtime metadata,
 model load time, warmup time, and per-size throughput.
+
+`--sizes` is the set of paper counts to measure. `--repeats` is the number of
+measured runs for each size. The benchmark runs one warmup embedding after model
+load, reports it as `warmup_seconds`, and excludes it from throughput results.
 
 Results are machine-specific. Use them to compare local changes such as
 different embedding models, pooling settings, max lengths, or future batch

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,27 @@
+# Benchmarks
+
+Local benchmarks for engineering measurements. These scripts are not part of
+the installed runtime package.
+
+## Embedding Latency
+
+Measure how long the configured embedding model takes to process representative
+title-and-abstract inputs on the current machine:
+
+```bash
+uv run python benchmarks/embedding_latency.py \
+  --config configs/config.json \
+  --sizes 1 10 100 \
+  --repeats 3 \
+  --warmup 1
+```
+
+The benchmark disables the embedding cache so results reflect model inference
+latency rather than cache hits.
+
+The output is JSON and includes model configuration, local runtime metadata,
+model load time, warmup time, and per-size throughput.
+
+Results are machine-specific. Use them to compare local changes such as
+different embedding models, pooling settings, max lengths, or future batch
+embedding support.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Local engineering benchmarks."""

--- a/benchmarks/embedding_latency.py
+++ b/benchmarks/embedding_latency.py
@@ -5,6 +5,7 @@ import json
 import platform
 import statistics
 import sys
+import textwrap
 from collections.abc import Callable, Sequence
 from time import perf_counter
 from typing import Any
@@ -23,19 +24,18 @@ Timer = Callable[[], float]
 VectorizerFactory = Callable[[AppConfig], TextEmbedder]
 
 
+class BenchmarkHelpFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    """Show defaults while preserving example formatting."""
+
+
 def positive_int(value: str) -> int:
     """Parse a positive integer for argparse."""
     parsed_value = int(value)
     if parsed_value <= 0:
         raise argparse.ArgumentTypeError("value must be greater than 0")
-    return parsed_value
-
-
-def non_negative_int(value: str) -> int:
-    """Parse a non-negative integer for argparse."""
-    parsed_value = int(value)
-    if parsed_value < 0:
-        raise argparse.ArgumentTypeError("value must be greater than or equal to 0")
     return parsed_value
 
 
@@ -76,7 +76,6 @@ def benchmark_embeddings(
     config: AppConfig,
     sizes: Sequence[int],
     repeats: int,
-    warmup: int,
     vectorizer_factory: VectorizerFactory = instantiate_vectorizer,
     timer: Timer = perf_counter,
 ) -> dict[str, Any]:
@@ -87,14 +86,12 @@ def benchmark_embeddings(
         raise ValueError("all sizes must be greater than 0")
     if repeats <= 0:
         raise ValueError("repeats must be greater than 0")
-    if warmup < 0:
-        raise ValueError("warmup must be greater than or equal to 0")
 
     load_start = timer()
     vectorizer = vectorizer_factory(config)
     model_load_seconds = timer() - load_start
 
-    warmup_seconds = run_warmup(vectorizer, warmup, timer)
+    warmup_seconds = run_warmup(vectorizer, timer)
     results = [
         benchmark_size(vectorizer=vectorizer, paper_count=size, repeats=repeats, timer=timer)
         for size in sizes
@@ -110,12 +107,9 @@ def benchmark_embeddings(
     }
 
 
-def run_warmup(vectorizer: TextEmbedder, warmup: int, timer: Timer) -> float:
-    """Run warmup embeddings before measuring benchmark sizes."""
-    if warmup == 0:
-        return 0.0
-
-    inputs = build_representative_inputs(warmup)
+def run_warmup(vectorizer: TextEmbedder, timer: Timer) -> float:
+    """Run one warmup embedding before measuring benchmark sizes."""
+    inputs = build_representative_inputs(1)
     start = timer()
     embed_inputs(vectorizer, inputs)
     return timer() - start
@@ -127,7 +121,12 @@ def benchmark_size(
     repeats: int,
     timer: Timer,
 ) -> dict[str, Any]:
-    """Measure repeated embedding runs for one input size."""
+    """Measure repeated embedding runs for one paper-count size.
+
+    Each repeat embeds a fresh set of deterministic inputs with a repeat marker
+    appended. That keeps cache-disabled measurements representative today and
+    prevents accidental cache hits if a future vectorizer ignores cache_size=0.
+    """
     elapsed_seconds = []
     for repeat_index in range(repeats):
         inputs = build_representative_inputs(paper_count)
@@ -189,26 +188,55 @@ def environment_metadata() -> dict[str, Any]:
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description="Benchmark embedding latency.")
-    parser.add_argument("--config", required=True, help="Path to application config JSON.")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure embedding latency for the configured vectorizer on "
+            "representative title-and-abstract inputs."
+        ),
+        formatter_class=BenchmarkHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            Examples:
+              uv run python benchmarks/embedding_latency.py --config configs/config.json
+              uv run python benchmarks/embedding_latency.py --config configs/config.json --sizes 1 10 100 --repeats 3
+
+            Argument notes:
+              --sizes controls the paper-count batches to time. For example,
+                '--sizes 1 10 100' measures one-paper, ten-paper, and
+                hundred-paper runs.
+              --repeats controls how many measured runs are executed for each
+                size. The report includes mean, best, and worst seconds.
+
+            The benchmark runs one warmup embedding after model load. Warmup
+            time is reported separately as warmup_seconds and excluded from
+            per-size throughput results.
+            """
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        default=argparse.SUPPRESS,
+        metavar="PATH",
+        help=(
+            "Application config JSON to load. The benchmark uses its vectorizer "
+            "settings and disables the embedding cache for measurement."
+        ),
+    )
     parser.add_argument(
         "--sizes",
         nargs="+",
         type=positive_int,
         default=[1, 10, 100],
-        help="Paper counts to benchmark.",
+        metavar="N",
+        help="One or more paper counts to benchmark.",
     )
     parser.add_argument(
         "--repeats",
         type=positive_int,
         default=3,
-        help="Number of measured repeats per size.",
-    )
-    parser.add_argument(
-        "--warmup",
-        type=non_negative_int,
-        default=1,
-        help="Number of warmup embeddings before measured runs.",
+        metavar="N",
+        help="Measured runs to execute for each size.",
     )
     return parser.parse_args()
 
@@ -221,7 +249,6 @@ def main() -> None:
         config=config,
         sizes=args.sizes,
         repeats=args.repeats,
-        warmup=args.warmup,
     )
     print(json.dumps(report, indent=2, sort_keys=True))
 

--- a/benchmarks/embedding_latency.py
+++ b/benchmarks/embedding_latency.py
@@ -24,13 +24,6 @@ Timer = Callable[[], float]
 VectorizerFactory = Callable[[AppConfig], TextEmbedder]
 
 
-class BenchmarkHelpFormatter(
-    argparse.ArgumentDefaultsHelpFormatter,
-    argparse.RawDescriptionHelpFormatter,
-):
-    """Show defaults while preserving example formatting."""
-
-
 def positive_int(value: str) -> int:
     """Parse a positive integer for argparse."""
     parsed_value = int(value)
@@ -193,7 +186,7 @@ def parse_args() -> argparse.Namespace:
             "Measure embedding latency for the configured vectorizer on "
             "representative title-and-abstract inputs."
         ),
-        formatter_class=BenchmarkHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent(
             """\
             Examples:
@@ -229,14 +222,14 @@ def parse_args() -> argparse.Namespace:
         type=positive_int,
         default=[1, 10, 100],
         metavar="N",
-        help="One or more paper counts to benchmark.",
+        help="One or more paper counts to benchmark. Default: 1 10 100.",
     )
     parser.add_argument(
         "--repeats",
         type=positive_int,
         default=3,
         metavar="N",
-        help="Measured runs to execute for each size.",
+        help="Measured runs to execute for each size. Default: 3.",
     )
     return parser.parse_args()
 

--- a/benchmarks/embedding_latency.py
+++ b/benchmarks/embedding_latency.py
@@ -1,0 +1,230 @@
+"""Measure embedding latency for representative title-and-abstract inputs."""
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+from collections.abc import Callable, Sequence
+from time import perf_counter
+from typing import Any
+
+try:
+    import torch
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore[assignment]
+
+from arxiv_recommender.schemas import AppConfig
+from arxiv_recommender.text_vectorization.base import TextEmbedder
+from arxiv_recommender.utils.config_loader import load_config
+from arxiv_recommender.utils.model_loader import load_vectorization_model
+
+Timer = Callable[[], float]
+VectorizerFactory = Callable[[AppConfig], TextEmbedder]
+
+
+def positive_int(value: str) -> int:
+    """Parse a positive integer for argparse."""
+    parsed_value = int(value)
+    if parsed_value <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than 0")
+    return parsed_value
+
+
+def non_negative_int(value: str) -> int:
+    """Parse a non-negative integer for argparse."""
+    parsed_value = int(value)
+    if parsed_value < 0:
+        raise argparse.ArgumentTypeError("value must be greater than or equal to 0")
+    return parsed_value
+
+
+def build_representative_inputs(count: int) -> list[str]:
+    """Build deterministic paper-like title-and-abstract inputs."""
+    if count <= 0:
+        raise ValueError("count must be greater than 0")
+
+    return [
+        (
+            f"Title: Representation learning for scientific paper recommendation {index}\n"
+            "Abstract: We study content-based recommendation for recent arXiv papers using "
+            "title and abstract text. The method embeds papers with a transformer encoder, "
+            "compares candidates against a user's favorite papers, and ranks results by "
+            "semantic similarity. Experiments analyze latency, cache behavior, and ranking "
+            "quality for local research discovery workflows."
+        )
+        for index in range(count)
+    ]
+
+
+def instantiate_vectorizer(config: AppConfig) -> TextEmbedder:
+    """Load the configured vectorizer with caching disabled for latency measurement."""
+    return load_vectorization_model(
+        module_name=config.vectorizer.module_name,
+        class_name=config.vectorizer.class_name,
+        model_name=config.vectorizer.model_name,
+        cache_size=0,
+        vectorizer_options={
+            "pooling_strategy": config.vectorizer.pooling_strategy,
+            "normalize_embeddings": config.vectorizer.normalize_embeddings,
+            "max_length": config.vectorizer.max_length,
+        },
+    )
+
+
+def benchmark_embeddings(
+    config: AppConfig,
+    sizes: Sequence[int],
+    repeats: int,
+    warmup: int,
+    vectorizer_factory: VectorizerFactory = instantiate_vectorizer,
+    timer: Timer = perf_counter,
+) -> dict[str, Any]:
+    """Run the embedding latency benchmark and return a JSON-serializable report."""
+    if not sizes:
+        raise ValueError("sizes must not be empty")
+    if any(size <= 0 for size in sizes):
+        raise ValueError("all sizes must be greater than 0")
+    if repeats <= 0:
+        raise ValueError("repeats must be greater than 0")
+    if warmup < 0:
+        raise ValueError("warmup must be greater than or equal to 0")
+
+    load_start = timer()
+    vectorizer = vectorizer_factory(config)
+    model_load_seconds = timer() - load_start
+
+    warmup_seconds = run_warmup(vectorizer, warmup, timer)
+    results = [
+        benchmark_size(vectorizer=vectorizer, paper_count=size, repeats=repeats, timer=timer)
+        for size in sizes
+    ]
+
+    return {
+        "benchmark": "embedding_latency",
+        "model": model_metadata(config),
+        "environment": environment_metadata(),
+        "model_load_seconds": model_load_seconds,
+        "warmup_seconds": warmup_seconds,
+        "results": results,
+    }
+
+
+def run_warmup(vectorizer: TextEmbedder, warmup: int, timer: Timer) -> float:
+    """Run warmup embeddings before measuring benchmark sizes."""
+    if warmup == 0:
+        return 0.0
+
+    inputs = build_representative_inputs(warmup)
+    start = timer()
+    embed_inputs(vectorizer, inputs)
+    return timer() - start
+
+
+def benchmark_size(
+    vectorizer: TextEmbedder,
+    paper_count: int,
+    repeats: int,
+    timer: Timer,
+) -> dict[str, Any]:
+    """Measure repeated embedding runs for one input size."""
+    elapsed_seconds = []
+    for repeat_index in range(repeats):
+        inputs = build_representative_inputs(paper_count)
+        inputs = [f"{text}\nBenchmark repeat: {repeat_index}" for text in inputs]
+        start = timer()
+        embed_inputs(vectorizer, inputs)
+        elapsed_seconds.append(timer() - start)
+
+    mean_seconds = statistics.fmean(elapsed_seconds)
+    return {
+        "paper_count": paper_count,
+        "repeat_count": repeats,
+        "mean_seconds": mean_seconds,
+        "best_seconds": min(elapsed_seconds),
+        "worst_seconds": max(elapsed_seconds),
+        "mean_papers_per_second": paper_count / mean_seconds if mean_seconds > 0 else None,
+    }
+
+
+def embed_inputs(vectorizer: TextEmbedder, inputs: Sequence[str]) -> None:
+    """Embed every input text."""
+    for text in inputs:
+        vectorizer.process(text)
+
+
+def model_metadata(config: AppConfig) -> dict[str, Any]:
+    """Return benchmark-relevant model configuration."""
+    normalize_embeddings = config.vectorizer.normalize_embeddings
+    if hasattr(normalize_embeddings, "value"):
+        normalize_embeddings = normalize_embeddings.value
+
+    return {
+        "module_name": config.vectorizer.module_name,
+        "class_name": config.vectorizer.class_name,
+        "model_name": config.vectorizer.model_name,
+        "pooling_strategy": config.vectorizer.pooling_strategy.value,
+        "normalize_embeddings": normalize_embeddings,
+        "max_length": config.vectorizer.max_length,
+        "cache_size": 0,
+    }
+
+
+def environment_metadata() -> dict[str, Any]:
+    """Return local runtime metadata for interpreting benchmark results."""
+    torch_version = None
+    torch_cuda_available = None
+    if torch is not None:
+        torch_version = torch.__version__
+        torch_cuda_available = torch.cuda.is_available()
+
+    return {
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+        "torch_version": torch_version,
+        "torch_cuda_available": torch_cuda_available,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Benchmark embedding latency.")
+    parser.add_argument("--config", required=True, help="Path to application config JSON.")
+    parser.add_argument(
+        "--sizes",
+        nargs="+",
+        type=positive_int,
+        default=[1, 10, 100],
+        help="Paper counts to benchmark.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=positive_int,
+        default=3,
+        help="Number of measured repeats per size.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=non_negative_int,
+        default=1,
+        help="Number of warmup embeddings before measured runs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the embedding latency benchmark."""
+    args = parse_args()
+    config = load_config(args.config)
+    report = benchmark_embeddings(
+        config=config,
+        sizes=args.sizes,
+        repeats=args.repeats,
+        warmup=args.warmup,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,7 +9,7 @@ recommender. Accepted decisions are recorded separately in `docs/decisions/`.
 - [x] L2-normalize embeddings and verify similarity behavior.
 - [x] Version cache entries by model and embedding configuration.
 - [x] Add focused unit tests for pooling, normalization, and caching.
-- [ ] Measure embedding latency on representative title-and-abstract inputs.
+- [x] Measure embedding latency on representative title-and-abstract inputs.
 
 ## Milestone 2: Local Feedback Vertical Slice
 

--- a/tests/benchmarks/test_embedding_latency.py
+++ b/tests/benchmarks/test_embedding_latency.py
@@ -1,0 +1,145 @@
+import argparse
+import json
+from typing import Any
+
+import numpy as np
+import pytest
+
+from arxiv_recommender.schemas import AppConfig, VectorizerConfig
+from arxiv_recommender.text_vectorization.base import TextEmbedder
+from benchmarks.embedding_latency import (
+    benchmark_embeddings,
+    build_representative_inputs,
+    non_negative_int,
+    positive_int,
+)
+
+
+class FakeVectorizer(TextEmbedder):
+    def __init__(self) -> None:
+        self.processed_texts: list[str] = []
+
+    def process(self, text: str) -> np.ndarray:
+        self.processed_texts.append(text)
+        return np.array([1.0, 0.0])
+
+    def get_cache_stats(self) -> dict[str, Any]:
+        return {}
+
+
+class FakeTimer:
+    def __init__(self) -> None:
+        self.current = 0.0
+
+    def __call__(self) -> float:
+        self.current += 1.0
+        return self.current
+
+
+def make_config() -> AppConfig:
+    return AppConfig(
+        favorite_papers_path="favorite_papers.json",
+        vectorizer=VectorizerConfig(
+            module_name="huggingface_embed",
+            class_name="HuggingFaceEmbedding",
+            model_name="BAAI/bge-small-en-v1.5",
+            cache_size=1000,
+            pooling_strategy="auto",
+            normalize_embeddings="auto",
+            max_length=512,
+        ),
+        top_k=10,
+        log_level="INFO",
+    )
+
+
+def test_build_representative_inputs_returns_unique_paper_like_texts() -> None:
+    inputs = build_representative_inputs(3)
+
+    assert len(inputs) == 3
+    assert len(set(inputs)) == 3
+    assert all("Title:" in text for text in inputs)
+    assert all("Abstract:" in text for text in inputs)
+
+
+def test_build_representative_inputs_rejects_non_positive_count() -> None:
+    with pytest.raises(ValueError, match="count must be greater than 0"):
+        build_representative_inputs(0)
+
+
+def test_positive_int_accepts_positive_values() -> None:
+    assert positive_int("3") == 3
+
+
+def test_positive_int_rejects_zero() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="value must be greater than 0"):
+        positive_int("0")
+
+
+def test_non_negative_int_accepts_zero() -> None:
+    assert non_negative_int("0") == 0
+
+
+def test_non_negative_int_rejects_negative_values() -> None:
+    with pytest.raises(
+        argparse.ArgumentTypeError,
+        match="value must be greater than or equal to 0",
+    ):
+        non_negative_int("-1")
+
+
+def test_benchmark_embeddings_returns_json_serializable_report() -> None:
+    fake_vectorizer = FakeVectorizer()
+
+    report = benchmark_embeddings(
+        config=make_config(),
+        sizes=[2],
+        repeats=2,
+        warmup=1,
+        vectorizer_factory=lambda _config: fake_vectorizer,
+        timer=FakeTimer(),
+    )
+
+    assert report["benchmark"] == "embedding_latency"
+    assert report["model"]["model_name"] == "BAAI/bge-small-en-v1.5"
+    assert report["model"]["cache_size"] == 0
+    assert report["model_load_seconds"] == 1.0
+    assert report["warmup_seconds"] == 1.0
+    assert report["results"] == [
+        {
+            "paper_count": 2,
+            "repeat_count": 2,
+            "mean_seconds": 1.0,
+            "best_seconds": 1.0,
+            "worst_seconds": 1.0,
+            "mean_papers_per_second": 2.0,
+        }
+    ]
+    assert len(fake_vectorizer.processed_texts) == 5
+    json.dumps(report)
+
+
+@pytest.mark.parametrize(
+    ("sizes", "repeats", "warmup", "match"),
+    [
+        ([], 1, 0, "sizes must not be empty"),
+        ([0], 1, 0, "all sizes must be greater than 0"),
+        ([1], 0, 0, "repeats must be greater than 0"),
+        ([1], 1, -1, "warmup must be greater than or equal to 0"),
+    ],
+)
+def test_benchmark_embeddings_validates_inputs(
+    sizes: list[int],
+    repeats: int,
+    warmup: int,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        benchmark_embeddings(
+            config=make_config(),
+            sizes=sizes,
+            repeats=repeats,
+            warmup=warmup,
+            vectorizer_factory=lambda _config: FakeVectorizer(),
+            timer=FakeTimer(),
+        )

--- a/tests/benchmarks/test_embedding_latency.py
+++ b/tests/benchmarks/test_embedding_latency.py
@@ -9,8 +9,8 @@ from arxiv_recommender.schemas import AppConfig, VectorizerConfig
 from arxiv_recommender.text_vectorization.base import TextEmbedder
 from benchmarks.embedding_latency import (
     benchmark_embeddings,
+    benchmark_size,
     build_representative_inputs,
-    non_negative_int,
     positive_int,
 )
 
@@ -76,18 +76,6 @@ def test_positive_int_rejects_zero() -> None:
         positive_int("0")
 
 
-def test_non_negative_int_accepts_zero() -> None:
-    assert non_negative_int("0") == 0
-
-
-def test_non_negative_int_rejects_negative_values() -> None:
-    with pytest.raises(
-        argparse.ArgumentTypeError,
-        match="value must be greater than or equal to 0",
-    ):
-        non_negative_int("-1")
-
-
 def test_benchmark_embeddings_returns_json_serializable_report() -> None:
     fake_vectorizer = FakeVectorizer()
 
@@ -95,7 +83,6 @@ def test_benchmark_embeddings_returns_json_serializable_report() -> None:
         config=make_config(),
         sizes=[2],
         repeats=2,
-        warmup=1,
         vectorizer_factory=lambda _config: fake_vectorizer,
         timer=FakeTimer(),
     )
@@ -119,19 +106,40 @@ def test_benchmark_embeddings_returns_json_serializable_report() -> None:
     json.dumps(report)
 
 
+def test_benchmark_size_measures_repeats_with_unique_inputs() -> None:
+    fake_vectorizer = FakeVectorizer()
+
+    result = benchmark_size(
+        vectorizer=fake_vectorizer,
+        paper_count=2,
+        repeats=2,
+        timer=FakeTimer(),
+    )
+
+    assert result == {
+        "paper_count": 2,
+        "repeat_count": 2,
+        "mean_seconds": 1.0,
+        "best_seconds": 1.0,
+        "worst_seconds": 1.0,
+        "mean_papers_per_second": 2.0,
+    }
+    assert len(fake_vectorizer.processed_texts) == 4
+    assert any("Benchmark repeat: 0" in text for text in fake_vectorizer.processed_texts)
+    assert any("Benchmark repeat: 1" in text for text in fake_vectorizer.processed_texts)
+
+
 @pytest.mark.parametrize(
-    ("sizes", "repeats", "warmup", "match"),
+    ("sizes", "repeats", "match"),
     [
-        ([], 1, 0, "sizes must not be empty"),
-        ([0], 1, 0, "all sizes must be greater than 0"),
-        ([1], 0, 0, "repeats must be greater than 0"),
-        ([1], 1, -1, "warmup must be greater than or equal to 0"),
+        ([], 1, "sizes must not be empty"),
+        ([0], 1, "all sizes must be greater than 0"),
+        ([1], 0, "repeats must be greater than 0"),
     ],
 )
 def test_benchmark_embeddings_validates_inputs(
     sizes: list[int],
     repeats: int,
-    warmup: int,
     match: str,
 ) -> None:
     with pytest.raises(ValueError, match=match):
@@ -139,7 +147,6 @@ def test_benchmark_embeddings_validates_inputs(
             config=make_config(),
             sizes=sizes,
             repeats=repeats,
-            warmup=warmup,
             vectorizer_factory=lambda _config: FakeVectorizer(),
             timer=FakeTimer(),
         )


### PR DESCRIPTION
## Summary
- add a local embedding latency benchmark under benchmarks/
- report model config, environment metadata, model load time, warmup time, and per-size throughput as JSON
- document benchmark usage in README and benchmarks/README.md
- add tests for input generation, validation, aggregation, and JSON serialization

## Verification
- uv run python -m pytest tests/benchmarks/test_embedding_latency.py
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest
- uv run python benchmarks/embedding_latency.py --help