### PR TITLE
feat: add sqlite migration foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ arxiv_recommender/
 │       ├── favorite_papers/           # Loads favorite papers from files or prompts
 │       ├── text_vectorization/       # Handles text embedding models
 │       ├── recommendation/           # Core recommendation logic
+│       ├── persistence/              # Local SQLite schema and migrations
 │       ├── schemas/                  # Pydantic models
 │       └── utils/                    # Utility functions
 ├── configs/

--- a/docs/personalized_recommender_design.md
+++ b/docs/personalized_recommender_design.md
@@ -101,9 +101,10 @@ are:
 - `feedback`: explicit interested/not-interested events
 - `model_versions`: embedding and ranker identifiers and configuration
 
-The exact schema will be proposed and reviewed before implementation.
-Persisted embeddings must be invalidated or separated when the embedding
-model, pooling, normalization, or text-construction policy changes.
+The initial schema and migration runner are implemented under
+`src/arxiv_recommender/persistence/`. Persisted embeddings must be invalidated
+or separated when the embedding model, pooling, normalization, or
+text-construction policy changes.
 
 ## Personalization Strategy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ recommender. Accepted decisions are recorded separately in `docs/decisions/`.
 
 ## Milestone 2: Local Feedback Vertical Slice
 
-- [ ] Define and review the SQLite schema and migration approach.
+- [x] Define and review the SQLite schema and migration approach.
 - [ ] Store papers, recommendation runs, and impressions.
 - [ ] Store explicit `interested` and `not_interested` feedback.
 - [ ] Record embedding model, ranker version, displayed rank, and score.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 
+[tool.setuptools.package-data]
+"arxiv_recommender.persistence.sql_migrations" = ["*.sql"]
+
 [[tool.mypy.overrides]]
 module = "requests"
 ignore_missing_imports = true

--- a/src/arxiv_recommender/persistence/__init__.py
+++ b/src/arxiv_recommender/persistence/__init__.py
@@ -1,0 +1,6 @@
+"""SQLite persistence helpers."""
+
+from arxiv_recommender.persistence.database import connect_database
+from arxiv_recommender.persistence.migrations import MigrationError, apply_migrations
+
+__all__ = ["MigrationError", "apply_migrations", "connect_database"]

--- a/src/arxiv_recommender/persistence/database.py
+++ b/src/arxiv_recommender/persistence/database.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sqlite3
+
+
+def connect_database(database_path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite database connection with application pragmas enabled."""
+    connection = sqlite3.connect(database_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA journal_mode = WAL")
+    return connection

--- a/src/arxiv_recommender/persistence/database.py
+++ b/src/arxiv_recommender/persistence/database.py
@@ -3,7 +3,15 @@ import sqlite3
 
 
 def connect_database(database_path: str | Path) -> sqlite3.Connection:
-    """Open a SQLite database connection with application pragmas enabled."""
+    """Open a SQLite database connection for application persistence.
+
+    Args:
+        database_path: Path to the SQLite database file.
+
+    Returns:
+        A SQLite connection configured to return rows by column name, enforce
+        foreign keys, and use write-ahead logging for normal app usage.
+    """
     connection = sqlite3.connect(database_path)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")

--- a/src/arxiv_recommender/persistence/migrations.py
+++ b/src/arxiv_recommender/persistence/migrations.py
@@ -31,7 +31,22 @@ def apply_migrations(
     connection: sqlite3.Connection,
     migrations: list[Migration] | None = None,
 ) -> None:
-    """Apply pending SQLite migrations in version order."""
+    """Apply all pending SQLite migrations in version order.
+
+    The runner checks `schema_migrations` to decide which migrations have
+    already run. A new database runs every packaged migration from the first
+    version to the latest version. An existing database runs only migrations
+    that have not been recorded yet.
+
+    Args:
+        connection: Open SQLite connection.
+        migrations: Optional explicit migration list for tests. Production
+            callers should omit this so packaged SQL files are used.
+
+    Raises:
+        MigrationError: If migrations are out of order, duplicated, edited
+            after being applied, or fail while executing.
+    """
     connection.execute("PRAGMA foreign_keys = ON")
     _ensure_migrations_table(connection)
 

--- a/src/arxiv_recommender/persistence/migrations.py
+++ b/src/arxiv_recommender/persistence/migrations.py
@@ -56,12 +56,21 @@ def apply_migrations(
     applied = _load_applied_migrations(connection)
     for migration in ordered_migrations:
         applied_checksum = applied.get(migration.version)
+
+        # Same version and checksum means this exact migration already ran.
+        # Skip it so repeated calls only apply newly added migration files.
         if applied_checksum == migration.checksum:
             continue
+
+        # Same version with a different checksum means a migration file was
+        # edited after being applied. Refuse to continue because the database
+        # history no longer matches the checked-in migration history.
         if applied_checksum is not None:
             raise MigrationError(
                 f"Applied migration {migration.version} checksum does not match local file."
             )
+
+        # No record exists for this version, so this migration is pending.
         _apply_migration(connection, migration)
 
 

--- a/src/arxiv_recommender/persistence/migrations.py
+++ b/src/arxiv_recommender/persistence/migrations.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+from importlib import resources
+import re
+import sqlite3
+
+
+MIGRATION_PACKAGE = "arxiv_recommender.persistence.sql_migrations"
+
+
+class MigrationError(RuntimeError):
+    """Raised when database migrations cannot be applied safely."""
+
+
+@dataclass(frozen=True)
+class Migration:
+    """A SQLite schema migration loaded from a SQL file."""
+
+    version: int
+    name: str
+    sql: str
+
+    @property
+    def checksum(self) -> str:
+        """Return the migration SQL checksum."""
+        return hashlib.sha256(self.sql.encode("utf-8")).hexdigest()
+
+
+def apply_migrations(
+    connection: sqlite3.Connection,
+    migrations: list[Migration] | None = None,
+) -> None:
+    """Apply pending SQLite migrations in version order."""
+    connection.execute("PRAGMA foreign_keys = ON")
+    _ensure_migrations_table(connection)
+
+    ordered_migrations = migrations or load_migrations()
+    _validate_migration_order(ordered_migrations)
+
+    applied = _load_applied_migrations(connection)
+    for migration in ordered_migrations:
+        applied_checksum = applied.get(migration.version)
+        if applied_checksum == migration.checksum:
+            continue
+        if applied_checksum is not None:
+            raise MigrationError(
+                f"Applied migration {migration.version} checksum does not match local file."
+            )
+        _apply_migration(connection, migration)
+
+
+def load_migrations() -> list[Migration]:
+    """Load packaged SQL migration files."""
+    migration_files = sorted(
+        (
+            path
+            for path in resources.files(MIGRATION_PACKAGE).iterdir()
+            if path.name.endswith(".sql")
+        ),
+        key=lambda path: path.name,
+    )
+    return [
+        _migration_from_file(path.name, path.read_text(encoding="utf-8"))
+        for path in migration_files
+    ]
+
+
+def _ensure_migrations_table(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            checksum TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _load_applied_migrations(connection: sqlite3.Connection) -> dict[int, str]:
+    rows = connection.execute("SELECT version, checksum FROM schema_migrations").fetchall()
+    return {int(row["version"]): str(row["checksum"]) for row in rows}
+
+
+def _apply_migration(connection: sqlite3.Connection, migration: Migration) -> None:
+    applied_at = datetime.now(timezone.utc).isoformat()
+    try:
+        connection.executescript(f"BEGIN;\n{migration.sql}")
+        connection.execute(
+            """
+            INSERT INTO schema_migrations(version, name, checksum, applied_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (migration.version, migration.name, migration.checksum, applied_at),
+        )
+        connection.execute("COMMIT")
+    except sqlite3.Error as exc:
+        connection.execute("ROLLBACK")
+        raise MigrationError(f"Failed to apply migration {migration.version}: {exc}") from exc
+
+
+def _migration_from_file(filename: str, sql: str) -> Migration:
+    match = re.fullmatch(r"(\d{4})_(.+)\.sql", filename)
+    if not match:
+        raise MigrationError(f"Invalid migration filename: {filename}")
+    return Migration(version=int(match.group(1)), name=match.group(2), sql=sql)
+
+
+def _validate_migration_order(migrations: list[Migration]) -> None:
+    versions = [migration.version for migration in migrations]
+    if versions != sorted(versions):
+        raise MigrationError("Migrations must be sorted by version.")
+    if len(versions) != len(set(versions)):
+        raise MigrationError("Migration versions must be unique.")

--- a/src/arxiv_recommender/persistence/sql_migrations/0001_initial.sql
+++ b/src/arxiv_recommender/persistence/sql_migrations/0001_initial.sql
@@ -1,0 +1,70 @@
+CREATE TABLE papers (
+    id INTEGER PRIMARY KEY,
+    arxiv_id TEXT UNIQUE,
+    url TEXT,
+    title TEXT NOT NULL,
+    abstract TEXT NOT NULL,
+    authors_json TEXT NOT NULL,
+    categories_json TEXT NOT NULL,
+    published_at TEXT,
+    updated_at TEXT,
+    created_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL
+);
+
+CREATE TABLE model_versions (
+    id INTEGER PRIMARY KEY,
+    model_kind TEXT NOT NULL CHECK(model_kind IN ('embedding', 'ranker')),
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    config_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(model_kind, name, version, config_json)
+);
+
+CREATE TABLE recommendation_runs (
+    id INTEGER PRIMARY KEY,
+    run_started_at TEXT NOT NULL,
+    run_completed_at TEXT,
+    requested_date TEXT,
+    favorite_papers_count INTEGER NOT NULL CHECK(favorite_papers_count >= 0),
+    candidate_papers_count INTEGER NOT NULL CHECK(candidate_papers_count >= 0),
+    top_k INTEGER NOT NULL CHECK(top_k > 0),
+    embedding_model_version_id INTEGER NOT NULL,
+    ranker_model_version_id INTEGER NOT NULL,
+    metrics_json TEXT NOT NULL,
+    FOREIGN KEY(embedding_model_version_id) REFERENCES model_versions(id),
+    FOREIGN KEY(ranker_model_version_id) REFERENCES model_versions(id)
+);
+
+CREATE TABLE impressions (
+    id INTEGER PRIMARY KEY,
+    recommendation_run_id INTEGER NOT NULL,
+    paper_id INTEGER NOT NULL,
+    displayed_rank INTEGER NOT NULL CHECK(displayed_rank > 0),
+    score REAL NOT NULL,
+    selection_source TEXT NOT NULL CHECK(
+        selection_source IN ('base_ranker', 'personal_ranker', 'exploration')
+    ),
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(recommendation_run_id) REFERENCES recommendation_runs(id),
+    FOREIGN KEY(paper_id) REFERENCES papers(id),
+    UNIQUE(recommendation_run_id, paper_id),
+    UNIQUE(recommendation_run_id, displayed_rank)
+);
+
+CREATE TABLE feedback (
+    id INTEGER PRIMARY KEY,
+    impression_id INTEGER NOT NULL,
+    value TEXT NOT NULL CHECK(value IN ('interested', 'not_interested')),
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(impression_id) REFERENCES impressions(id)
+);
+
+CREATE INDEX idx_papers_arxiv_id ON papers(arxiv_id);
+CREATE INDEX idx_recommendation_runs_started_at
+    ON recommendation_runs(run_started_at);
+CREATE INDEX idx_impressions_run_id ON impressions(recommendation_run_id);
+CREATE INDEX idx_impressions_paper_id ON impressions(paper_id);
+CREATE INDEX idx_feedback_impression_id ON feedback(impression_id);
+CREATE INDEX idx_feedback_created_at ON feedback(created_at);

--- a/src/arxiv_recommender/persistence/sql_migrations/0001_initial.sql
+++ b/src/arxiv_recommender/persistence/sql_migrations/0001_initial.sql
@@ -12,6 +12,9 @@ CREATE TABLE papers (
     last_seen_at TEXT NOT NULL
 );
 
+-- Store embedding and ranker provenance separately from recommendation runs so
+-- historical evaluation can identify which model contract produced each
+-- impression without duplicating config JSON on every run.
 CREATE TABLE model_versions (
     id INTEGER PRIMARY KEY,
     model_kind TEXT NOT NULL CHECK(model_kind IN ('embedding', 'ranker')),

--- a/src/arxiv_recommender/persistence/sql_migrations/__init__.py
+++ b/src/arxiv_recommender/persistence/sql_migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged SQLite migration files."""

--- a/tests/persistence/__init__.py
+++ b/tests/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Persistence tests."""

--- a/tests/persistence/test_migrations.py
+++ b/tests/persistence/test_migrations.py
@@ -1,0 +1,213 @@
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from arxiv_recommender.persistence import MigrationError, apply_migrations, connect_database
+from arxiv_recommender.persistence.migrations import Migration
+
+
+class TestMigrations(unittest.TestCase):
+    def _connect_temp_database(self) -> sqlite3.Connection:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        database_path = Path(temp_dir.name) / "recommendations.sqlite"
+        connection = connect_database(database_path)
+        self.addCleanup(connection.close)
+        return connection
+
+    def test_apply_migrations_creates_initial_schema(self) -> None:
+        connection = self._connect_temp_database()
+
+        apply_migrations(connection)
+
+        table_names = {
+            row["name"]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        self.assertEqual(
+            {
+                "schema_migrations",
+                "papers",
+                "model_versions",
+                "recommendation_runs",
+                "impressions",
+                "feedback",
+            },
+            table_names,
+        )
+
+    def test_apply_migrations_is_idempotent(self) -> None:
+        connection = self._connect_temp_database()
+
+        apply_migrations(connection)
+        apply_migrations(connection)
+
+        migration_count = connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+        self.assertEqual(1, migration_count)
+
+    def test_apply_migrations_rejects_checksum_mismatch(self) -> None:
+        connection = self._connect_temp_database()
+        original_migration = Migration(
+            version=1,
+            name="test",
+            sql="CREATE TABLE example (id INTEGER PRIMARY KEY);",
+        )
+        changed_migration = Migration(
+            version=1,
+            name="test",
+            sql="CREATE TABLE example (id INTEGER PRIMARY KEY, name TEXT);",
+        )
+
+        apply_migrations(connection, migrations=[original_migration])
+
+        with self.assertRaisesRegex(MigrationError, "checksum does not match"):
+            apply_migrations(connection, migrations=[changed_migration])
+
+    def test_connection_enforces_foreign_keys(self) -> None:
+        connection = self._connect_temp_database()
+
+        apply_migrations(connection)
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            connection.execute(
+                """
+                INSERT INTO feedback(impression_id, value, created_at)
+                VALUES (?, ?, ?)
+                """,
+                (999, "interested", "2026-07-20T00:00:00+00:00"),
+            )
+
+    def test_initial_schema_supports_feedback_event_flow(self) -> None:
+        connection = self._connect_temp_database()
+        timestamp = "2026-07-20T00:00:00+00:00"
+
+        apply_migrations(connection)
+
+        paper_id = connection.execute(
+            """
+            INSERT INTO papers(
+                arxiv_id,
+                url,
+                title,
+                abstract,
+                authors_json,
+                categories_json,
+                published_at,
+                updated_at,
+                created_at,
+                last_seen_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "2607.12345",
+                "https://arxiv.org/abs/2607.12345",
+                "A Test Paper",
+                "A test abstract.",
+                json.dumps(["Ada Lovelace"]),
+                json.dumps(["cs.IR"]),
+                timestamp,
+                timestamp,
+                timestamp,
+                timestamp,
+            ),
+        ).lastrowid
+        embedding_model_id = connection.execute(
+            """
+            INSERT INTO model_versions(model_kind, name, version, config_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "embedding",
+                "BAAI/bge-small-en-v1.5",
+                "model=BAAI/bge-small-en-v1.5|pooling=cls|normalize=True|max_length=512",
+                json.dumps({"pooling_strategy": "cls", "normalize_embeddings": True}),
+                timestamp,
+            ),
+        ).lastrowid
+        ranker_model_id = connection.execute(
+            """
+            INSERT INTO model_versions(model_kind, name, version, config_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "ranker",
+                "base_similarity",
+                "1",
+                json.dumps({"score_policy": "max_cosine_similarity_to_favorites"}),
+                timestamp,
+            ),
+        ).lastrowid
+        recommendation_run_id = connection.execute(
+            """
+            INSERT INTO recommendation_runs(
+                run_started_at,
+                run_completed_at,
+                requested_date,
+                favorite_papers_count,
+                candidate_papers_count,
+                top_k,
+                embedding_model_version_id,
+                ranker_model_version_id,
+                metrics_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                timestamp,
+                timestamp,
+                "20260720",
+                2,
+                25,
+                10,
+                embedding_model_id,
+                ranker_model_id,
+                json.dumps({"embedding_latency": []}),
+            ),
+        ).lastrowid
+        impression_id = connection.execute(
+            """
+            INSERT INTO impressions(
+                recommendation_run_id,
+                paper_id,
+                displayed_rank,
+                score,
+                selection_source,
+                created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (recommendation_run_id, paper_id, 1, 0.87, "base_ranker", timestamp),
+        ).lastrowid
+
+        connection.execute(
+            """
+            INSERT INTO feedback(impression_id, value, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (impression_id, "interested", timestamp),
+        )
+        connection.execute(
+            """
+            INSERT INTO feedback(impression_id, value, created_at)
+            VALUES (?, ?, ?)
+            """,
+            (impression_id, "not_interested", "2026-07-20T00:05:00+00:00"),
+        )
+
+        feedback_values = [
+            row["value"]
+            for row in connection.execute(
+                "SELECT value FROM feedback WHERE impression_id = ? ORDER BY created_at",
+                (impression_id,),
+            ).fetchall()
+        ]
+        self.assertEqual(["interested", "not_interested"], feedback_values)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/persistence/test_migrations.py
+++ b/tests/persistence/test_migrations.py
@@ -105,8 +105,8 @@ class TestMigrations(unittest.TestCase):
         with self.assertRaisesRegex(MigrationError, "checksum does not match"):
             apply_migrations(connection, migrations=[changed_migration])
 
-    def test_schema_rejects_feedback_without_matching_impression(self) -> None:
-        """Feedback must reference a real impression."""
+    def test_schema_rejects_feedback_with_unknown_impression_id(self) -> None:
+        """Feedback with a nonexistent impression_id must be rejected."""
         connection = self._connect_temp_database()
 
         apply_migrations(connection)

--- a/tests/persistence/test_migrations.py
+++ b/tests/persistence/test_migrations.py
@@ -17,7 +17,8 @@ class TestMigrations(unittest.TestCase):
         self.addCleanup(connection.close)
         return connection
 
-    def test_apply_migrations_creates_initial_schema(self) -> None:
+    def test_apply_migrations_loads_packaged_sql_files_by_default(self) -> None:
+        """Default migration application uses the real packaged SQL files."""
         connection = self._connect_temp_database()
 
         apply_migrations(connection)
@@ -40,14 +41,51 @@ class TestMigrations(unittest.TestCase):
             table_names,
         )
 
-    def test_apply_migrations_is_idempotent(self) -> None:
+    def test_apply_migrations_skips_already_applied_migrations(self) -> None:
+        """Running migrations twice should not rerun SQL already recorded."""
         connection = self._connect_temp_database()
 
         apply_migrations(connection)
+        first_applied_row = connection.execute(
+            "SELECT version, applied_at FROM schema_migrations"
+        ).fetchone()
         apply_migrations(connection)
 
+        second_applied_row = connection.execute(
+            "SELECT version, applied_at FROM schema_migrations"
+        ).fetchone()
         migration_count = connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
         self.assertEqual(1, migration_count)
+        self.assertEqual(first_applied_row["version"], second_applied_row["version"])
+        self.assertEqual(first_applied_row["applied_at"], second_applied_row["applied_at"])
+
+    def test_apply_migrations_runs_pending_migrations_in_order(self) -> None:
+        connection = self._connect_temp_database()
+        initial_migration = Migration(
+            version=1,
+            name="create_example",
+            sql="CREATE TABLE example (id INTEGER PRIMARY KEY);",
+        )
+        pending_migration = Migration(
+            version=2,
+            name="add_example_name",
+            sql="ALTER TABLE example ADD COLUMN name TEXT;",
+        )
+
+        apply_migrations(connection, migrations=[initial_migration])
+        apply_migrations(connection, migrations=[initial_migration, pending_migration])
+
+        migration_versions = [
+            row["version"]
+            for row in connection.execute(
+                "SELECT version FROM schema_migrations ORDER BY version"
+            ).fetchall()
+        ]
+        example_columns = [
+            row["name"] for row in connection.execute("PRAGMA table_info(example)").fetchall()
+        ]
+        self.assertEqual([1, 2], migration_versions)
+        self.assertEqual(["id", "name"], example_columns)
 
     def test_apply_migrations_rejects_checksum_mismatch(self) -> None:
         connection = self._connect_temp_database()
@@ -67,7 +105,8 @@ class TestMigrations(unittest.TestCase):
         with self.assertRaisesRegex(MigrationError, "checksum does not match"):
             apply_migrations(connection, migrations=[changed_migration])
 
-    def test_connection_enforces_foreign_keys(self) -> None:
+    def test_schema_rejects_feedback_without_matching_impression(self) -> None:
+        """Feedback must reference a real impression."""
         connection = self._connect_temp_database()
 
         apply_migrations(connection)
@@ -81,7 +120,7 @@ class TestMigrations(unittest.TestCase):
                 (999, "interested", "2026-07-20T00:00:00+00:00"),
             )
 
-    def test_initial_schema_supports_feedback_event_flow(self) -> None:
+    def test_initial_schema_supports_recommendation_feedback_event_flow(self) -> None:
         connection = self._connect_temp_database()
         timestamp = "2026-07-20T00:00:00+00:00"
 
@@ -199,6 +238,25 @@ class TestMigrations(unittest.TestCase):
             (impression_id, "not_interested", "2026-07-20T00:05:00+00:00"),
         )
 
+        stored_paper = connection.execute(
+            "SELECT title FROM papers WHERE id = ?", (paper_id,)
+        ).fetchone()
+        stored_run = connection.execute(
+            """
+            SELECT embedding_model_version_id, ranker_model_version_id
+            FROM recommendation_runs
+            WHERE id = ?
+            """,
+            (recommendation_run_id,),
+        ).fetchone()
+        stored_impression = connection.execute(
+            """
+            SELECT recommendation_run_id, paper_id, displayed_rank, selection_source
+            FROM impressions
+            WHERE id = ?
+            """,
+            (impression_id,),
+        ).fetchone()
         feedback_values = [
             row["value"]
             for row in connection.execute(
@@ -206,6 +264,13 @@ class TestMigrations(unittest.TestCase):
                 (impression_id,),
             ).fetchall()
         ]
+        self.assertEqual("A Test Paper", stored_paper["title"])
+        self.assertEqual(embedding_model_id, stored_run["embedding_model_version_id"])
+        self.assertEqual(ranker_model_id, stored_run["ranker_model_version_id"])
+        self.assertEqual(recommendation_run_id, stored_impression["recommendation_run_id"])
+        self.assertEqual(paper_id, stored_impression["paper_id"])
+        self.assertEqual(1, stored_impression["displayed_rank"])
+        self.assertEqual("base_ranker", stored_impression["selection_source"])
         self.assertEqual(["interested", "not_interested"], feedback_values)
 
 

--- a/tests/persistence/test_migrations.py
+++ b/tests/persistence/test_migrations.py
@@ -13,7 +13,7 @@ class TestMigrations(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(temp_dir.cleanup)
         database_path = Path(temp_dir.name) / "recommendations.sqlite"
-        connection = connect_database(database_path)
+        connection: sqlite3.Connection = connect_database(database_path)
         self.addCleanup(connection.close)
         return connection
 
@@ -41,7 +41,7 @@ class TestMigrations(unittest.TestCase):
             table_names,
         )
 
-    def test_apply_migrations_skips_already_applied_migrations(self) -> None:
+    def test_apply_migrations_is_idempotent_for_already_applied_migrations(self) -> None:
         """Running migrations twice should not rerun SQL already recorded."""
         connection = self._connect_temp_database()
 


### PR DESCRIPTION
## Summary
- add SQLite connection helper with foreign key enforcement and WAL mode
- add first-party SQL migration runner with ordered migrations, checksum validation, and idempotent application
- add initial schema for papers, model versions, recommendation runs, impressions, and feedback
- add focused migration tests

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest