### PR TITLE
feat: add recommendation persistence repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ arxiv_recommender/
 │       ├── favorite_papers/           # Loads favorite papers from files or prompts
 │       ├── text_vectorization/       # Handles text embedding models
 │       ├── recommendation/           # Core recommendation logic
-│       ├── persistence/              # Local SQLite schema and migrations
+│       ├── persistence/              # SQLite schema, migrations, and repositories
 │       ├── schemas/                  # Pydantic models
 │       └── utils/                    # Utility functions
 ├── configs/

--- a/docs/personalized_recommender_design.md
+++ b/docs/personalized_recommender_design.md
@@ -101,10 +101,17 @@ are:
 - `feedback`: explicit interested/not-interested events
 - `model_versions`: embedding and ranker identifiers and configuration
 
-The initial schema and migration runner are implemented under
-`src/arxiv_recommender/persistence/`. Persisted embeddings must be invalidated
-or separated when the embedding model, pooling, normalization, or
-text-construction policy changes.
+The initial schema, migration runner, and recommendation repository are
+implemented under `src/arxiv_recommender/persistence/`. Repository inputs and
+outputs are validated with Pydantic, and each recommendation run is stored in
+one transaction so partial model, paper, run, or impression records are rolled
+back together. Only papers selected for display are retained as papers and
+impressions; the total fetched candidate count remains part of the run record.
+Embedding and ranker version records are reused through canonical configuration
+JSON. The repository is not connected to the CLI workflow yet.
+
+Persisted embeddings must be invalidated or separated when the embedding model,
+pooling, normalization, or text-construction policy changes.
 
 ## Personalization Strategy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,16 +27,19 @@ recommender. Accepted decisions are recorded separately in `docs/decisions/`.
 
 Suggested branch: `feat/recommendation-persistence`
 
-- Add validated persistence input and output models.
-- Add a repository for recommendation runs.
-- Store only papers included in the displayed recommendation list.
-- Insert or reuse embedding and ranker model versions.
-- Insert recommendation runs and displayed impressions atomically.
-- Return structured recommendation-run and impression identifiers.
-- Roll back the complete operation when any persistence step fails.
-- Add integration tests using temporary migrated SQLite databases.
+- [x] Add validated persistence input and output models.
+- [x] Add a repository for recommendation runs.
+- [x] Store only papers included in the displayed recommendation list.
+- [x] Insert or reuse embedding and ranker model versions.
+- [x] Insert recommendation runs and displayed impressions atomically.
+- [x] Return structured recommendation-run and impression identifiers.
+- [x] Roll back the complete operation when any persistence step fails.
+- [x] Add integration tests using temporary migrated SQLite databases.
 
-This PR introduces the persistence API without changing CLI behavior.
+Status: Implemented in PR #39.
+
+The repository API is complete, but the top-level persistence item remains open
+until PR 3 wires it into the CLI workflow.
 
 #### PR 2: Ranking Provenance
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,54 @@ recommender. Accepted decisions are recorded separately in `docs/decisions/`.
 - [ ] Add interested and not-interested controls with clear saved/error states.
 - [ ] Add persistence and workflow tests.
 
+### Planned Implementation PRs
+
+#### PR 1: Recommendation Persistence Repository
+
+Suggested branch: `feat/recommendation-persistence`
+
+- Add validated persistence input and output models.
+- Add a repository for recommendation runs.
+- Store only papers included in the displayed recommendation list.
+- Insert or reuse embedding and ranker model versions.
+- Insert recommendation runs and displayed impressions atomically.
+- Return structured recommendation-run and impression identifiers.
+- Roll back the complete operation when any persistence step fails.
+- Add integration tests using temporary migrated SQLite databases.
+
+This PR introduces the persistence API without changing CLI behavior.
+
+#### PR 2: Ranking Provenance
+
+Suggested branch: `feat/ranking-provenance`
+
+- Define developer-maintained metadata for the base ranker.
+- Record its algorithm name, semantic version, and canonical configuration.
+- Expose resolved embedding provenance through the text-embedding interface.
+- Store resolved pooling, normalization, maximum length, and text policy.
+- Add a typed impression selection source.
+- Update embedding implementations, test doubles, and provenance tests.
+
+Ranker versions are maintained by developers rather than configured by users.
+They change when scoring semantics or score-affecting implementation behavior
+changes.
+
+#### PR 3: Persist CLI Recommendation Runs
+
+Suggested branch: `feat/persist-cli-runs`
+
+- Add a configurable local database path.
+- Capture run start time, completion time, and effective requested date.
+- Connect to the database and apply migrations during CLI startup.
+- Persist a completed run before displaying its recommendations.
+- Store displayed rank, score, selection source, metrics, and model-version
+  references.
+- Add CLI and end-to-end workflow tests.
+- Document the database location and displayed-paper retention policy.
+
+After this PR, CLI recommendation history is durable. Explicit feedback
+controls remain a separate subsequent roadmap item.
+
 ## Milestone 3: Historical Evaluation
 
 - [ ] Implement chronological dataset construction from local feedback.

--- a/src/arxiv_recommender/persistence/__init__.py
+++ b/src/arxiv_recommender/persistence/__init__.py
@@ -2,5 +2,31 @@
 
 from arxiv_recommender.persistence.database import connect_database
 from arxiv_recommender.persistence.migrations import MigrationError, apply_migrations
+from arxiv_recommender.persistence.models import (
+    DisplayedRecommendation,
+    ModelKind,
+    ModelVersionSpec,
+    RecommendationRunRecord,
+    SelectionSource,
+    StoredImpression,
+    StoredRecommendationRun,
+)
+from arxiv_recommender.persistence.repository import (
+    RecommendationPersistenceError,
+    RecommendationRepository,
+)
 
-__all__ = ["MigrationError", "apply_migrations", "connect_database"]
+__all__ = [
+    "DisplayedRecommendation",
+    "MigrationError",
+    "ModelKind",
+    "ModelVersionSpec",
+    "RecommendationPersistenceError",
+    "RecommendationRepository",
+    "RecommendationRunRecord",
+    "SelectionSource",
+    "StoredImpression",
+    "StoredRecommendationRun",
+    "apply_migrations",
+    "connect_database",
+]

--- a/src/arxiv_recommender/persistence/models.py
+++ b/src/arxiv_recommender/persistence/models.py
@@ -1,0 +1,153 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field, JsonValue, field_validator, model_validator
+
+from arxiv_recommender.schemas import Paper
+
+
+class ModelKind(str, Enum):
+    """Supported persisted model categories."""
+
+    EMBEDDING = "embedding"
+    RANKER = "ranker"
+
+
+class SelectionSource(str, Enum):
+    """Reason a recommendation was selected for display."""
+
+    BASE_RANKER = "base_ranker"
+    PERSONAL_RANKER = "personal_ranker"
+    EXPLORATION = "exploration"
+
+
+class ModelVersionSpec(BaseModel):
+    """Validated identity and configuration for a persisted model version."""
+
+    model_kind: ModelKind
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    config: dict[str, JsonValue] = Field(default_factory=dict)
+
+    model_config = {"frozen": True}
+
+    @field_validator("name", "version")
+    @classmethod
+    def validate_non_empty_identity(cls, value: str) -> str:
+        """Normalize and reject blank model identity fields."""
+        normalized_value = value.strip()
+        if not normalized_value:
+            raise ValueError("Model name and version must not be blank.")
+        return normalized_value
+
+
+class DisplayedRecommendation(BaseModel):
+    """A recommendation that was selected for display."""
+
+    paper: Paper
+    displayed_rank: int = Field(gt=0)
+    score: float = Field(allow_inf_nan=False)
+    selection_source: SelectionSource
+
+    model_config = {"frozen": True}
+
+    @model_validator(mode="after")
+    def validate_paper_identity(self) -> "DisplayedRecommendation":
+        """Require a stable paper identity before persistence."""
+        if self.paper.arxiv_id is None or not self.paper.arxiv_id.strip():
+            raise ValueError("Displayed recommendations require a non-empty arxiv_id.")
+        for field_name, timestamp in (
+            ("published", self.paper.published),
+            ("updated", self.paper.updated),
+        ):
+            if timestamp is not None and timestamp.utcoffset() is None:
+                raise ValueError(f"Paper {field_name} timestamp must be timezone-aware.")
+        return self
+
+
+class RecommendationRunRecord(BaseModel):
+    """Validated recommendation run ready for atomic persistence."""
+
+    run_started_at: datetime
+    run_completed_at: datetime | None = None
+    requested_date: str | None = Field(default=None, pattern=r"^\d{8}$")
+    favorite_papers_count: int = Field(ge=0)
+    candidate_papers_count: int = Field(ge=0)
+    top_k: int = Field(gt=0)
+    embedding_model: ModelVersionSpec
+    ranker_model: ModelVersionSpec
+    metrics: dict[str, JsonValue] = Field(default_factory=dict)
+    displayed_recommendations: list[DisplayedRecommendation] = Field(default_factory=list)
+
+    model_config = {"frozen": True}
+
+    @field_validator("run_started_at", "run_completed_at")
+    @classmethod
+    def validate_timezone_aware_timestamp(cls, value: datetime | None) -> datetime | None:
+        """Require unambiguous timestamps for chronological evaluation."""
+        if value is not None and value.utcoffset() is None:
+            raise ValueError("Recommendation run timestamps must be timezone-aware.")
+        return value
+
+    @field_validator("requested_date")
+    @classmethod
+    def validate_requested_date(cls, value: str | None) -> str | None:
+        """Require a real calendar date when a requested date is present."""
+        if value is not None:
+            try:
+                datetime.strptime(value, "%Y%m%d")
+            except ValueError as exc:
+                raise ValueError("requested_date must be a valid date in YYYYMMDD format.") from exc
+        return value
+
+    @model_validator(mode="after")
+    def validate_run_contract(self) -> "RecommendationRunRecord":
+        """Validate cross-field constraints for a persistable run."""
+        if self.embedding_model.model_kind is not ModelKind.EMBEDDING:
+            raise ValueError("embedding_model must have model_kind='embedding'.")
+        if self.ranker_model.model_kind is not ModelKind.RANKER:
+            raise ValueError("ranker_model must have model_kind='ranker'.")
+        if self.run_completed_at is not None and self.run_completed_at < self.run_started_at:
+            raise ValueError("run_completed_at must not be earlier than run_started_at.")
+
+        recommendation_count = len(self.displayed_recommendations)
+        if recommendation_count > self.top_k:
+            raise ValueError("Displayed recommendation count must not exceed top_k.")
+        if recommendation_count > self.candidate_papers_count:
+            raise ValueError(
+                "Displayed recommendation count must not exceed candidate_papers_count."
+            )
+
+        displayed_ranks = [
+            recommendation.displayed_rank for recommendation in self.displayed_recommendations
+        ]
+        expected_ranks = list(range(1, recommendation_count + 1))
+        if displayed_ranks != expected_ranks:
+            raise ValueError("Displayed recommendations must have sequential ranks starting at 1.")
+
+        arxiv_ids = [
+            recommendation.paper.arxiv_id for recommendation in self.displayed_recommendations
+        ]
+        if len(arxiv_ids) != len(set(arxiv_ids)):
+            raise ValueError("A paper cannot be displayed more than once in the same run.")
+
+        return self
+
+
+class StoredImpression(BaseModel):
+    """Database identifiers assigned to one stored impression."""
+
+    impression_id: int = Field(gt=0)
+    paper_id: int = Field(gt=0)
+    displayed_rank: int = Field(gt=0)
+
+    model_config = {"frozen": True}
+
+
+class StoredRecommendationRun(BaseModel):
+    """Database identifiers assigned to a stored recommendation run."""
+
+    run_id: int = Field(gt=0)
+    impressions: list[StoredImpression] = Field(default_factory=list)
+
+    model_config = {"frozen": True}

--- a/src/arxiv_recommender/persistence/repository.py
+++ b/src/arxiv_recommender/persistence/repository.py
@@ -1,0 +1,285 @@
+from datetime import datetime, timezone
+import json
+import sqlite3
+
+from arxiv_recommender.persistence.models import (
+    DisplayedRecommendation,
+    ModelVersionSpec,
+    RecommendationRunRecord,
+    StoredImpression,
+    StoredRecommendationRun,
+)
+from arxiv_recommender.schemas import Paper
+
+
+class RecommendationPersistenceError(RuntimeError):
+    """Raised when a recommendation run cannot be persisted atomically."""
+
+
+class RecommendationRepository:
+    """Persist recommendation runs and displayed papers in SQLite."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        """Initialize the repository with an open, migrated connection.
+
+        Args:
+            connection: SQLite connection whose schema migrations have already
+                been applied.
+        """
+        self._connection = connection
+
+    def record_recommendation_run(
+        self,
+        record: RecommendationRunRecord,
+    ) -> StoredRecommendationRun:
+        """Persist a recommendation run and its displayed results atomically.
+
+        Args:
+            record: Validated run metadata, model provenance, and displayed
+                recommendations.
+
+        Returns:
+            Database identifiers for the stored run and impressions.
+
+        Raises:
+            RecommendationPersistenceError: If the connection already has an
+                active transaction or any database write fails.
+        """
+        if self._connection.in_transaction:
+            raise RecommendationPersistenceError(
+                "Cannot record a recommendation run during an active transaction."
+            )
+
+        try:
+            embedding_config_json = _canonical_json(record.embedding_model.config)
+            ranker_config_json = _canonical_json(record.ranker_model.config)
+            metrics_json = _canonical_json(record.metrics)
+        except (TypeError, ValueError) as exc:
+            raise RecommendationPersistenceError(
+                "Recommendation run contains data that cannot be serialized as JSON."
+            ) from exc
+
+        event_timestamp = record.run_completed_at or record.run_started_at
+
+        try:
+            self._connection.execute("BEGIN")
+            embedding_model_id = self._upsert_model_version(
+                record.embedding_model,
+                embedding_config_json,
+                event_timestamp,
+            )
+            ranker_model_id = self._upsert_model_version(
+                record.ranker_model,
+                ranker_config_json,
+                event_timestamp,
+            )
+            run_id = self._insert_recommendation_run(
+                record,
+                embedding_model_id,
+                ranker_model_id,
+                metrics_json,
+            )
+            stored_impressions = [
+                self._insert_displayed_recommendation(
+                    run_id,
+                    recommendation,
+                    event_timestamp,
+                )
+                for recommendation in record.displayed_recommendations
+            ]
+            self._connection.execute("COMMIT")
+        except RecommendationPersistenceError:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+        except (sqlite3.Error, ValueError) as exc:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise RecommendationPersistenceError("Failed to persist recommendation run.") from exc
+
+        return StoredRecommendationRun(run_id=run_id, impressions=stored_impressions)
+
+    def _upsert_model_version(
+        self,
+        model: ModelVersionSpec,
+        config_json: str,
+        created_at: datetime,
+    ) -> int:
+        self._connection.execute(
+            """
+            INSERT INTO model_versions(model_kind, name, version, config_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(model_kind, name, version, config_json) DO NOTHING
+            """,
+            (
+                model.model_kind.value,
+                model.name,
+                model.version,
+                config_json,
+                _utc_isoformat(created_at),
+            ),
+        )
+        row = self._connection.execute(
+            """
+            SELECT id
+            FROM model_versions
+            WHERE model_kind = ? AND name = ? AND version = ? AND config_json = ?
+            """,
+            (model.model_kind.value, model.name, model.version, config_json),
+        ).fetchone()
+        if row is None:
+            raise RecommendationPersistenceError("Stored model version could not be loaded.")
+        return int(row[0])
+
+    def _insert_recommendation_run(
+        self,
+        record: RecommendationRunRecord,
+        embedding_model_id: int,
+        ranker_model_id: int,
+        metrics_json: str,
+    ) -> int:
+        cursor = self._connection.execute(
+            """
+            INSERT INTO recommendation_runs(
+                run_started_at,
+                run_completed_at,
+                requested_date,
+                favorite_papers_count,
+                candidate_papers_count,
+                top_k,
+                embedding_model_version_id,
+                ranker_model_version_id,
+                metrics_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                _utc_isoformat(record.run_started_at),
+                (
+                    _utc_isoformat(record.run_completed_at)
+                    if record.run_completed_at is not None
+                    else None
+                ),
+                record.requested_date,
+                record.favorite_papers_count,
+                record.candidate_papers_count,
+                record.top_k,
+                embedding_model_id,
+                ranker_model_id,
+                metrics_json,
+            ),
+        )
+        return _last_inserted_id(cursor, "recommendation run")
+
+    def _insert_displayed_recommendation(
+        self,
+        run_id: int,
+        recommendation: DisplayedRecommendation,
+        created_at: datetime,
+    ) -> StoredImpression:
+        paper_id = self._upsert_paper(recommendation.paper, created_at)
+        cursor = self._connection.execute(
+            """
+            INSERT INTO impressions(
+                recommendation_run_id,
+                paper_id,
+                displayed_rank,
+                score,
+                selection_source,
+                created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                paper_id,
+                recommendation.displayed_rank,
+                recommendation.score,
+                recommendation.selection_source.value,
+                _utc_isoformat(created_at),
+            ),
+        )
+        return StoredImpression(
+            impression_id=_last_inserted_id(cursor, "impression"),
+            paper_id=paper_id,
+            displayed_rank=recommendation.displayed_rank,
+        )
+
+    def _upsert_paper(self, paper: Paper, seen_at: datetime) -> int:
+        arxiv_id = paper.arxiv_id
+        if arxiv_id is None:
+            raise RecommendationPersistenceError(
+                "Displayed recommendations require a non-empty arxiv_id."
+            )
+
+        seen_at_text = _utc_isoformat(seen_at)
+        self._connection.execute(
+            """
+            INSERT INTO papers(
+                arxiv_id,
+                url,
+                title,
+                abstract,
+                authors_json,
+                categories_json,
+                published_at,
+                updated_at,
+                created_at,
+                last_seen_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(arxiv_id) DO UPDATE SET
+                url = excluded.url,
+                title = excluded.title,
+                abstract = excluded.abstract,
+                authors_json = excluded.authors_json,
+                categories_json = excluded.categories_json,
+                published_at = excluded.published_at,
+                updated_at = excluded.updated_at,
+                last_seen_at = excluded.last_seen_at
+            """,
+            (
+                arxiv_id,
+                paper.url,
+                paper.title,
+                paper.abstract,
+                _canonical_json(paper.authors),
+                _canonical_json(paper.categories),
+                _optional_utc_isoformat(paper.published),
+                _optional_utc_isoformat(paper.updated),
+                seen_at_text,
+                seen_at_text,
+            ),
+        )
+        row = self._connection.execute(
+            "SELECT id FROM papers WHERE arxiv_id = ?",
+            (arxiv_id,),
+        ).fetchone()
+        if row is None:
+            raise RecommendationPersistenceError("Stored paper could not be loaded.")
+        return int(row[0])
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _utc_isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _optional_utc_isoformat(value: datetime | None) -> str | None:
+    return _utc_isoformat(value) if value is not None else None
+
+
+def _last_inserted_id(cursor: sqlite3.Cursor, record_name: str) -> int:
+    row_id = cursor.lastrowid
+    if row_id is None:
+        raise RecommendationPersistenceError(f"Could not determine stored {record_name} ID.")
+    return int(row_id)

--- a/tests/persistence/test_repository.py
+++ b/tests/persistence/test_repository.py
@@ -1,0 +1,319 @@
+from datetime import datetime, timedelta, timezone
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from pydantic import JsonValue, ValidationError
+
+from arxiv_recommender.persistence import (
+    DisplayedRecommendation,
+    ModelKind,
+    ModelVersionSpec,
+    RecommendationPersistenceError,
+    RecommendationRepository,
+    RecommendationRunRecord,
+    SelectionSource,
+    apply_migrations,
+    connect_database,
+)
+from arxiv_recommender.schemas import Paper
+
+
+class TestRecommendationRepository(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        database_path = Path(temp_dir.name) / "recommendations.sqlite"
+        self.connection: sqlite3.Connection = connect_database(database_path)
+        self.addCleanup(self.connection.close)
+        apply_migrations(self.connection)
+        self.repository = RecommendationRepository(self.connection)
+        self.started_at = datetime(2026, 7, 29, 9, 0, tzinfo=timezone.utc)
+        self.completed_at = self.started_at + timedelta(seconds=8)
+
+    def _embedding_model(
+        self,
+        config: dict[str, JsonValue] | None = None,
+    ) -> ModelVersionSpec:
+        return ModelVersionSpec(
+            model_kind=ModelKind.EMBEDDING,
+            name="BAAI/bge-small-en-v1.5",
+            version="bge-small-cls-normalized-v1",
+            config=config
+            or {
+                "pooling_strategy": "cls",
+                "normalize_embeddings": True,
+                "max_length": 512,
+            },
+        )
+
+    def _ranker_model(
+        self,
+        config: dict[str, JsonValue] | None = None,
+    ) -> ModelVersionSpec:
+        return ModelVersionSpec(
+            model_kind=ModelKind.RANKER,
+            name="max_favorite_cosine_similarity",
+            version="1",
+            config=config
+            or {
+                "similarity": "cosine",
+                "favorite_aggregation": "max",
+            },
+        )
+
+    def _displayed_recommendation(
+        self,
+        rank: int,
+        arxiv_id: str | None = None,
+        title: str | None = None,
+    ) -> DisplayedRecommendation:
+        paper_id = arxiv_id or f"2607.{rank:05d}"
+        return DisplayedRecommendation(
+            paper=Paper(
+                arxiv_id=paper_id,
+                url=f"https://arxiv.org/abs/{paper_id}",
+                title=title or f"Paper {rank}",
+                abstract=f"Abstract {rank}",
+                authors=[f"Author {rank}"],
+                categories=["cs.IR"],
+                published=self.started_at - timedelta(days=1),
+                updated=self.started_at,
+            ),
+            displayed_rank=rank,
+            score=0.9 - (rank * 0.1),
+            selection_source=SelectionSource.BASE_RANKER,
+        )
+
+    def _run_record(
+        self,
+        recommendations: list[DisplayedRecommendation] | None = None,
+        embedding_model: ModelVersionSpec | None = None,
+        ranker_model: ModelVersionSpec | None = None,
+    ) -> RecommendationRunRecord:
+        displayed_recommendations = recommendations
+        if displayed_recommendations is None:
+            displayed_recommendations = [
+                self._displayed_recommendation(rank) for rank in range(1, 4)
+            ]
+        return RecommendationRunRecord(
+            run_started_at=self.started_at,
+            run_completed_at=self.completed_at,
+            requested_date="20260728",
+            favorite_papers_count=2,
+            candidate_papers_count=25,
+            top_k=3,
+            embedding_model=embedding_model or self._embedding_model(),
+            ranker_model=ranker_model or self._ranker_model(),
+            metrics={"cache": {"hits": 2, "misses": 25}},
+            displayed_recommendations=displayed_recommendations,
+        )
+
+    def _table_count(self, table_name: str) -> int:
+        allowed_tables = {
+            "papers",
+            "model_versions",
+            "recommendation_runs",
+            "impressions",
+        }
+        if table_name not in allowed_tables:
+            raise ValueError(f"Unsupported test table: {table_name}")
+        row = self.connection.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()
+        return int(row[0])
+
+    def test_records_run_and_only_displayed_papers(self) -> None:
+        record = self._run_record()
+
+        stored_run = self.repository.record_recommendation_run(record)
+
+        self.assertEqual(1, self._table_count("recommendation_runs"))
+        self.assertEqual(2, self._table_count("model_versions"))
+        self.assertEqual(3, self._table_count("papers"))
+        self.assertEqual(3, self._table_count("impressions"))
+        self.assertEqual(1, stored_run.run_id)
+        self.assertEqual([1, 2, 3], [item.displayed_rank for item in stored_run.impressions])
+
+        stored_database_run = self.connection.execute(
+            """
+            SELECT
+                candidate_papers_count,
+                top_k,
+                embedding_model_version_id,
+                ranker_model_version_id,
+                metrics_json
+            FROM recommendation_runs
+            WHERE id = ?
+            """,
+            (stored_run.run_id,),
+        ).fetchone()
+        self.assertEqual(25, stored_database_run["candidate_papers_count"])
+        self.assertEqual(3, stored_database_run["top_k"])
+        self.assertNotEqual(
+            stored_database_run["embedding_model_version_id"],
+            stored_database_run["ranker_model_version_id"],
+        )
+        self.assertEqual(
+            {"cache": {"hits": 2, "misses": 25}},
+            json.loads(stored_database_run["metrics_json"]),
+        )
+
+        stored_impressions = self.connection.execute(
+            """
+            SELECT displayed_rank, score, selection_source
+            FROM impressions
+            ORDER BY displayed_rank
+            """
+        ).fetchall()
+        self.assertEqual([1, 2, 3], [row["displayed_rank"] for row in stored_impressions])
+        self.assertEqual(
+            ["base_ranker", "base_ranker", "base_ranker"],
+            [row["selection_source"] for row in stored_impressions],
+        )
+        self.assertAlmostEqual(0.8, stored_impressions[0]["score"])
+
+    def test_reuses_paper_and_model_versions_across_runs(self) -> None:
+        first_record = self._run_record(
+            recommendations=[
+                self._displayed_recommendation(1, arxiv_id="2607.12345", title="First title")
+            ]
+        )
+        second_record = first_record.model_copy(
+            update={
+                "run_started_at": self.started_at + timedelta(days=1),
+                "run_completed_at": self.completed_at + timedelta(days=1),
+                "displayed_recommendations": [
+                    self._displayed_recommendation(
+                        1,
+                        arxiv_id="2607.12345",
+                        title="Updated title",
+                    )
+                ],
+            }
+        )
+
+        first_stored_run = self.repository.record_recommendation_run(first_record)
+        second_stored_run = self.repository.record_recommendation_run(second_record)
+
+        self.assertEqual(2, self._table_count("recommendation_runs"))
+        self.assertEqual(2, self._table_count("model_versions"))
+        self.assertEqual(1, self._table_count("papers"))
+        self.assertEqual(2, self._table_count("impressions"))
+        self.assertEqual(
+            first_stored_run.impressions[0].paper_id,
+            second_stored_run.impressions[0].paper_id,
+        )
+        paper = self.connection.execute(
+            "SELECT title, created_at, last_seen_at FROM papers WHERE arxiv_id = ?",
+            ("2607.12345",),
+        ).fetchone()
+        self.assertEqual("Updated title", paper["title"])
+        self.assertEqual(self.completed_at.isoformat(), paper["created_at"])
+        self.assertEqual(
+            (self.completed_at + timedelta(days=1)).isoformat(),
+            paper["last_seen_at"],
+        )
+
+    def test_canonical_model_json_reuses_semantically_identical_config(self) -> None:
+        first_embedding_model = self._embedding_model(
+            {
+                "pooling_strategy": "cls",
+                "normalize_embeddings": True,
+                "max_length": 512,
+            }
+        )
+        second_embedding_model = self._embedding_model(
+            {
+                "max_length": 512,
+                "normalize_embeddings": True,
+                "pooling_strategy": "cls",
+            }
+        )
+
+        self.repository.record_recommendation_run(
+            self._run_record(embedding_model=first_embedding_model)
+        )
+        second_record = self._run_record(embedding_model=second_embedding_model).model_copy(
+            update={
+                "run_started_at": self.started_at + timedelta(days=1),
+                "run_completed_at": self.completed_at + timedelta(days=1),
+            }
+        )
+        self.repository.record_recommendation_run(second_record)
+
+        embedding_rows = self.connection.execute(
+            """
+            SELECT config_json
+            FROM model_versions
+            WHERE model_kind = 'embedding'
+            """
+        ).fetchall()
+        self.assertEqual(1, len(embedding_rows))
+        self.assertEqual(
+            ('{"max_length":512,"normalize_embeddings":true,"pooling_strategy":"cls"}'),
+            embedding_rows[0]["config_json"],
+        )
+
+    def test_database_failure_rolls_back_complete_run(self) -> None:
+        self.connection.execute(
+            """
+            CREATE TRIGGER reject_second_impression
+            BEFORE INSERT ON impressions
+            WHEN NEW.displayed_rank = 2
+            BEGIN
+                SELECT RAISE(ABORT, 'second impression rejected');
+            END
+            """
+        )
+
+        with self.assertRaises(RecommendationPersistenceError):
+            self.repository.record_recommendation_run(self._run_record())
+
+        self.assertEqual(0, self._table_count("recommendation_runs"))
+        self.assertEqual(0, self._table_count("model_versions"))
+        self.assertEqual(0, self._table_count("papers"))
+        self.assertEqual(0, self._table_count("impressions"))
+
+    def test_missing_arxiv_id_is_rejected_before_database_write(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "non-empty arxiv_id"):
+            DisplayedRecommendation(
+                paper=Paper(title="No identity", abstract="Cannot be persisted"),
+                displayed_rank=1,
+                score=0.5,
+                selection_source=SelectionSource.BASE_RANKER,
+            )
+
+        self.assertEqual(0, self._table_count("recommendation_runs"))
+        self.assertEqual(0, self._table_count("papers"))
+        self.assertEqual(0, self._table_count("impressions"))
+
+    def test_run_record_rejects_invalid_display_contract(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "sequential ranks"):
+            self._run_record(
+                recommendations=[
+                    self._displayed_recommendation(1),
+                    self._displayed_recommendation(3),
+                ]
+            )
+
+        with self.assertRaisesRegex(ValidationError, "model_kind='embedding'"):
+            self._run_record(embedding_model=self._ranker_model())
+
+    def test_records_empty_completed_run_without_impressions(self) -> None:
+        record = self._run_record(recommendations=[]).model_copy(
+            update={"candidate_papers_count": 0}
+        )
+
+        stored_run = self.repository.record_recommendation_run(record)
+
+        self.assertEqual(1, stored_run.run_id)
+        self.assertEqual([], stored_run.impressions)
+        self.assertEqual(1, self._table_count("recommendation_runs"))
+        self.assertEqual(2, self._table_count("model_versions"))
+        self.assertEqual(0, self._table_count("papers"))
+        self.assertEqual(0, self._table_count("impressions"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add validated persistence input and output models
- atomically store model versions, recommendation runs, displayed papers, and impressions
- reuse paper and model-version rows with canonical JSON configuration
- return structured run and impression identifiers
- add integration coverage for displayed-only retention, reuse, validation, empty runs, and rollback behavior
- document the three planned Milestone 2 implementation PRs

## Testing

- uv run ruff check .
- uv run ruff format --check .
- uv run python -m mypy src
- uv run python -m pytest (160 passed)

## Scope

This PR adds the repository API and tests without changing CLI behavior or the database schema.